### PR TITLE
support propertyOrder

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 import decimal
+from collections import OrderedDict
 
 from marshmallow import fields, missing, Schema
 from marshmallow.compat import text_type, binary_type
@@ -78,8 +79,11 @@ class JSONSchema(Schema):
         mapping[fields.List] = list
         mapping[fields.Url] = text_type
         mapping[fields.LocalDateTime] = datetime.datetime
-        properties = {}
-        for field_name, field in sorted(obj.fields.items()):
+        if obj.ordered:
+            properties = OrderedDict()
+        else:
+            properties = {}
+        for count, (field_name, field) in enumerate(obj.fields.items()):
             if hasattr(field, '_jsonschema_type_mapping'):
                 schema = field._jsonschema_type_mapping()
             elif field.__class__ in mapping:
@@ -89,6 +93,8 @@ class JSONSchema(Schema):
                 schema = _from_nested_schema(field)
             else:
                 raise ValueError('unsupported field type %s' % field)
+            if obj.ordered:
+                schema['propertyOrder'] = count + 1
             properties[field.name] = schema
         return properties
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -67,4 +67,23 @@ class TestDumpSchema(BaseTest):
         json_schema = JSONSchema()
         dumped = json_schema.dump(schema).data
         self.assertEqual(dumped['properties']['favourite_colour'],
-                        {'type': 'string'})
+                         {'type': 'string'})
+
+    def test_property_order(self):
+
+        class UserSchema(Schema):
+            first = fields.String()
+            second = fields.String()
+            third = fields.String()
+            fourth = fields.String()
+
+            class Meta:
+                ordered = True
+
+        schema = UserSchema()
+        json_schema = JSONSchema()
+        dumped = json_schema.dump(schema).data
+        self.assertEqual(dumped['properties']['first']['propertyOrder'], 1)
+        self.assertEqual(dumped['properties']['second']['propertyOrder'], 2)
+        self.assertEqual(dumped['properties']['third']['propertyOrder'], 3)
+        self.assertEqual(dumped['properties']['fourth']['propertyOrder'], 4)


### PR DESCRIPTION
this is not a part of the v4 spec. It is proposed to be included
in v5, however it is likely that it will not actually make it
in the official specification.

See: https://github.com/json-schema/json-schema/issues/119
