### PR TITLE
Prevent PyPandoc failing install process.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError. OSError):
+except (IOError, ImportError, OSError):
     long_description = read('README.md')
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError):
+except (IOError, ImportError. OSError):
     long_description = read('README.md')
 
 setup(


### PR DESCRIPTION
### Changes:

* Adds an except around `OSError` for the conversion of the README from RST to MD. This is needed because, if PyPandoc is installed, but Pandoc is NOT, then this conversion fails with that exception and nothing gets installed!

### Repro Steps:

* Install Pandoc.
* Install PyPandoc.
* Uninstall Pandoc.
* Try to install `marshmallow-jsonschema`.
* **BUG:** Fails with OSError.