### PR TITLE
Account for allow_none.

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -107,7 +107,9 @@ class JSONSchema(Schema):
                     schema = FIELD_VALIDATORS[validator.__class__](
                         schema, field, validator, obj
                     )
-
+            if field.allow_none:
+                schema['type'] = [schema['type'], 'null']
+                
             properties[field.name] = schema
 
         return properties


### PR DESCRIPTION
When allow_none is set to True in the marshmallow schema, we have to add 'null' to the list of possible types. Other wise you get a None is not a Number error.
