### PR TITLE
adding meta ordered preserves order.

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -2,6 +2,8 @@ import datetime
 import uuid
 import decimal
 
+from collections import OrderedDict
+
 from marshmallow import fields, missing, Schema, validate
 from marshmallow.class_registry import get_class
 from marshmallow.compat import text_type, binary_type, basestring
@@ -106,9 +108,9 @@ class JSONSchema(Schema):
     def get_properties(self, obj):
         """Fill out properties field."""
         mapping = self._get_default_mapping(obj)
-        properties = {}
+        properties = OrderedDict()
 
-        for field_name, field in sorted(obj.fields.items()):
+        for field_name, field in obj.fields.items():
             schema = self._get_schema_for_field(obj, field)
             properties[field.name] = schema
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -22,6 +22,23 @@ def test_dump_schema():
     for field_name, field in schema.fields.items():
         assert field_name in props
 
+def test_dump_ordered():
+    """Order should be preserved."""
+
+    class AddressOrdered(Address):
+        """Just set ordered meta field."""
+
+        class Meta:  # noqa
+            ordered = True
+
+    schema = AddressOrdered()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    assert (
+        dumped['definitions']['AddressOrdered']['properties'].keys() ==
+        ['id', 'street', 'number', 'city', 'floor']
+    )
+
 def test_default():
     schema = UserSchema()
     json_schema = JSONSchema()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -35,7 +35,7 @@ def test_dump_ordered():
     json_schema = JSONSchema()
     dumped = json_schema.dump(schema).data
     assert (
-        dumped['definitions']['AddressOrdered']['properties'].keys() ==
+        list(dumped['definitions']['AddressOrdered']['properties'].keys()) ==
         ['id', 'street', 'number', 'city', 'floor']
     )
 


### PR DESCRIPTION
Property order wasn't preserved when the Meta field 'ordered' was set to True. 'tis now!