### PR TITLE
Fix to enable compatibility with brutusin/json-forms v1.6.3

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -225,7 +225,7 @@ class JSONSchema(Schema):
 
         if field.many:
             schema = {
-                'type': ["array"] if field.required else ['array', 'null'],
+                'type': "array" if field.required else ['array', 'null'],
                 'items': schema,
             }
 


### PR DESCRIPTION
It looks like json-forms doesn't make any accomodations for multiple
types [1]. Resulting in `Nested(multiple=True)` schemas not rendering
(as of json-forms v1.6.3).

This small change keeps generated schemas valid, and enables some level
of compatibility.

Admittedly, This doesn't solve the issue when `required=False` on nested fields, but I'm not a competent JS developer, and can't submit a PR for json-forms.

[1] https://github.com/brutusin/json-forms/blob/fcd15f14a7e97003efb12a6b70856c8c582a077b/src/js/brutusin-json-forms.js#L1090