### PR TITLE
add field metadata to serialized definition

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -140,16 +140,19 @@ class JSONSchema(Schema):
             json_schema['default'] = field.default
 
         # NOTE: doubled up to maintain backwards compatibility
-        metadata = field.metadata.get('metadata', {})
+        metadata = field.metadata.pop('metadata', {})
         metadata.update(field.metadata)
 
         if metadata.get('description'):
             json_schema['description'] = (
-                metadata.get('description')
+                metadata.pop('description')
             )
 
         if metadata.get('title'):
-            json_schema['title'] = metadata.get('title')
+            json_schema['title'] = metadata.pop('title')
+
+        for md_key, md_val in metadata.items():
+            json_schema[md_key] = md_val
 
         if isinstance(field, fields.List):
             json_schema['items'] = self._get_schema_for_field(
@@ -212,16 +215,19 @@ class JSONSchema(Schema):
         }
 
         # NOTE: doubled up to maintain backwards compatibility
-        metadata = field.metadata.get('metadata', {})
+        metadata = field.metadata.pop('metadata', {})
         metadata.update(field.metadata)
 
         if metadata.get('description'):
             schema['description'] = (
-                metadata.get('description')
+                metadata.pop('description')
             )
 
         if metadata.get('title'):
-            schema['title'] = metadata.get('title')
+            schema['title'] = metadata.pop('title')
+
+        for md_key, md_val in metadata.items():
+            schema[md_key] = md_val
 
         if field.many:
             schema = {

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -140,10 +140,12 @@ class JSONSchema(Schema):
             json_schema['default'] = field.default
 
         # NOTE: doubled up to maintain backwards compatibility
-        metadata = field.metadata.pop('metadata', {})
+        metadata = field.metadata.get('metadata', {})
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
+            if md_key == 'metadata':
+                continue
             json_schema[md_key] = md_val
 
         if isinstance(field, fields.List):
@@ -207,10 +209,12 @@ class JSONSchema(Schema):
         }
 
         # NOTE: doubled up to maintain backwards compatibility
-        metadata = field.metadata.pop('metadata', {})
+        metadata = field.metadata.get('metadata', {})
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
+            if md_key == 'metadata':
+                continue
             schema[md_key] = md_val
 
         if field.many:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -143,14 +143,6 @@ class JSONSchema(Schema):
         metadata = field.metadata.pop('metadata', {})
         metadata.update(field.metadata)
 
-        if metadata.get('description'):
-            json_schema['description'] = (
-                metadata.pop('description')
-            )
-
-        if metadata.get('title'):
-            json_schema['title'] = metadata.pop('title')
-
         for md_key, md_val in metadata.items():
             json_schema[md_key] = md_val
 
@@ -217,14 +209,6 @@ class JSONSchema(Schema):
         # NOTE: doubled up to maintain backwards compatibility
         metadata = field.metadata.pop('metadata', {})
         metadata.update(field.metadata)
-
-        if metadata.get('description'):
-            schema['description'] = (
-                metadata.pop('description')
-            )
-
-        if metadata.get('title'):
-            schema['title'] = metadata.pop('title')
 
         for md_key, md_val in metadata.items():
             schema[md_key] = md_val

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -35,13 +35,14 @@ def test_metadata():
     """Metadata should be available in the field definition."""
     class TestSchema(Schema):
         myfield = fields.String(metadata={'foo': 'Bar'})
-        yourfield = fields.Integer(required=True)
+        yourfield = fields.Integer(required=True, baz="waz")
     schema = TestSchema()
     json_schema = JSONSchema()
     dumped = json_schema.dump(schema).data
     _validate_schema(dumped)
     props = dumped['definitions']['TestSchema']['properties']
     assert props['myfield']['foo'] == 'Bar'
+    assert props['yourfield']['baz'] == 'waz'
 
 
 def test_descriptions():

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -43,7 +43,16 @@ def test_metadata():
     props = dumped['definitions']['TestSchema']['properties']
     assert props['myfield']['foo'] == 'Bar'
     assert props['yourfield']['baz'] == 'waz'
+    assert 'metadata' not in props['myfield']
+    assert 'metadata' not in props['yourfield']
 
+    # repeat process to assure idempotency
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    props = dumped['definitions']['TestSchema']['properties']
+    assert props['myfield']['foo'] == 'Bar'
+    assert props['yourfield']['baz'] == 'waz'
 
 def test_descriptions():
     class TestSchema(Schema):

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -30,6 +30,20 @@ def test_default():
     props = dumped['definitions']['UserSchema']['properties']
     assert props['id']['default'] == 'no-id'
 
+
+def test_metadata():
+    """Metadata should be available in the field definition."""
+    class TestSchema(Schema):
+        myfield = fields.String(metadata={'foo': 'Bar'})
+        yourfield = fields.Integer(required=True)
+    schema = TestSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    props = dumped['definitions']['TestSchema']['properties']
+    assert props['myfield']['foo'] == 'Bar'
+
+
 def test_descriptions():
     class TestSchema(Schema):
         myfield = fields.String(metadata={'description': 'Brown Cow'})


### PR DESCRIPTION
Partially related to #38 and not fixed by #39 -- arbitrary metadata is not added to the serialized output (only description and title are) -- this PR fixes #46, and more generally solves #45