### PR TITLE
Handle validate.oneOf(iterable)

### DIFF
--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -66,8 +66,8 @@ def handle_one_of(schema, field, validator, parent_schema):
             altered.
     """
     if validator.choices:
-        schema['enum'] = validator.choices
-        schema['enumNames'] = validator.labels
+        schema['enum'] = list(validator.choices)
+        schema['enumNames'] = list(validator.labels)
 
     return schema
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -453,8 +453,8 @@ def test_dumps_iterable_enums():
     dumped = json_schema.dump(schema).data
 
     assert dumped['definitions']['TestSchema']['properties']['foo'] == {
-        'enum': [0, 1, 2],
-        'enumNames': ['a', 'b', 'c'],
+        'enum': [v for v in mapping.values()],
+        'enumNames': [k for k in mapping.keys()],
         'format': 'integer',
         'title': 'foo',
         'type': 'number'

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -440,3 +440,22 @@ def test_metadata_direct_from_field():
         'type': 'string',
         'description': 'Directly on the field!',
     }
+
+def test_dumps_iterable_enums():
+    mapping = {'a': 0, 'b': 1, 'c': 2}
+
+    class TestSchema(Schema):
+        foo = fields.Integer(validate=validate.OneOf(
+            mapping.values(), labels=mapping.keys()))
+
+    schema = TestSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+
+    assert dumped['definitions']['TestSchema']['properties']['foo'] == {
+        'enum': [0, 1, 2],
+        'enumNames': ['a', 'b', 'c'],
+        'format': 'integer',
+        'title': 'foo',
+        'type': 'number'
+    }


### PR DESCRIPTION
According to the marshmallow docs for [validate.OneOf], the enum choices and labels are iterables, not necessarily lists.

[validate.OneOf]: http://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.validate.OneOf

Fixes a bug where a valid Marshmallow schema run through marshmallow-jsonschema could generate an object that could not be serialized as JSON.

See [behavior without the patch](https://gist.github.com/erik/b50cefeeefd1efcab0aa79743109ea99) for details