### PR TITLE
Add support for constructed nested schemas #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+.pytest_cache


### PR DESCRIPTION
Also isort imports in `base.py` and ignored `.pytest_cache`

Fix for #18 