### PR TITLE
Removing empty required as per https://tools.ietf.org/html/draft-fge-…

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -6,6 +6,7 @@ from marshmallow import fields, missing, Schema, validate
 from marshmallow.class_registry import get_class
 from marshmallow.compat import text_type, binary_type, basestring
 from marshmallow.decorators import post_dump
+from marshmallow.utils import missing
 
 from .validation import handle_length, handle_one_of, handle_range
 
@@ -122,7 +123,10 @@ class JSONSchema(Schema):
             if field.required:
                 required.append(field.name)
 
-        return required
+        if required:
+            return required
+        else:
+            return missing
 
     def _from_python_type(self, obj, field, pytype):
         """Get schema definition from python type."""

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -440,3 +440,13 @@ def test_metadata_direct_from_field():
         'type': 'string',
         'description': 'Directly on the field!',
     }
+
+
+def test_required_excluded_when_empty():
+
+    class TestSchema(Schema):
+        optional_value = fields.String()
+    schema = TestSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    assert 'required' not in dumped['definitions']['TestSchema']


### PR DESCRIPTION
`required` has a min length of 1 as per https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3

> The value of this keyword MUST be an array.  This array MUST have at
> least one element.  Elements of this array MUST be strings, and MUST
> be unique.

Returning missing from `get_required` allows objects where no fields are required to pass jsonschema draft4 validators.