### PR TITLE
Use __class__ attribute to create a JSONSchema form for Nested

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -195,7 +195,7 @@ class JSONSchema(Schema):
         # If this is not a schema we've seen, and it's not this schema,
         # put it in our list of schema defs
         if name not in self._nested_schema_classes and name != outer_name:
-            wrapped_nested = JSONSchema(nested=True)
+            wrapped_nested = self.__class__(nested=True)
             wrapped_dumped = wrapped_nested.dump(
                 nested(only=only, exclude=exclude)
             )


### PR DESCRIPTION
When you do a subclass of `JSONSchema` and a field is `Nested` it will be useful that the new JSONScheme will be the same type of the subclass.