### PR TITLE
Use black to format source code and add pre-commit hooks for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/python/black
+  rev: 19.3b0
+  hooks:
+  - id: black
+    language_version: python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,32 @@ language: python
 cache: pip
 matrix:
   include:
+  # Separate job for linting
+    - os: linux
+      python: "3.7"
+      env: TOXENV=lint
   # Separate testing for different marshmallow versions in different jobs to ease debugging
-  - os: linux
-    python: "3.7"
-    env: TOXENV=py37-marshmallow2
-  - os: linux
-    python: "3.7"
-    env: TOXENV=py37-marshmallow3
-  # These will test for both versions of marshmallow thanks to tox-travis package
-  - os: linux
-    python: "3.6"
-  - os: linux
-    python: "3.5"
-  - os: linux
-    python: "2.7"
-    env: TOXENV=py27-marshmallow2
-  - os: linux
-    python: "2.7"
-    env: TOXENV=py27-marshmallow3
-  - os: linux
-    python: "pypy3"
-  - os: linux
-    python: "pypy"
+    - os: linux
+      python: "3.7"
+      env: TOXENV=py37-marshmallow2
+    - os: linux
+      python: "3.7"
+      env: TOXENV=py37-marshmallow3
+    # These will test for both versions of marshmallow thanks to tox-travis package
+    - os: linux
+      python: "3.6"
+    - os: linux
+      python: "3.5"
+    - os: linux
+      python: "2.7"
+      env: TOXENV=py27-marshmallow2
+    - os: linux
+      python: "2.7"
+      env: TOXENV=py27-marshmallow3
+    - os: linux
+      python: "pypy3"
+    - os: linux
+      python: "pypy"
 before_install:
   - pip install -U pip
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+Setting Up for Local Development
+********************************
+
+1. Fork marshmallow_jsonschema on Github.
+
+::
+
+    $ git clone https://github.com/fuhrysteve/marshmallow-jsonschema.git
+    $ cd marshmallow_jsonschema
+
+2. Create a virtual environment and install all dependencies
+
+::
+
+    $ make venv
+
+3. Install the pre-commit hooks, which will format and lint your git staged files.
+
+::
+
+    # The pre-commit CLI was installed above
+    $ pre-commit install --allow-missing-config
+
+
+Running tests
+*************
+
+To run all tests: ::
+
+    $ pytest
+
+To run syntax checks: ::
+
+    $ tox -e lint
+
+(Optional) To run tests in all supported Python versions in their own virtual environments (must have each interpreter installed): ::
+
+    $ tox

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/fuhrysteve/marshmallow-jsonschema.svg?branch=master)](https://travis-ci.org/fuhrysteve/marshmallow-jsonschema)
 [![Coverage Status](https://coveralls.io/repos/github/fuhrysteve/marshmallow-jsonschema/badge.svg?branch=master)](https://coveralls.io/github/fuhrysteve/marshmallow-jsonschema?branch=master)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
  marshmallow-jsonschema translates marshmallow schemas into
  JSON Schema Draft v4 compliant jsonschema. See http://json-schema.org/

--- a/example/example.py
+++ b/example/example.py
@@ -10,15 +10,15 @@ class UserSchema(Schema):
     address = fields.String()
 
 
-@app.route('/schema')
+@app.route("/schema")
 def schema():
     schema = UserSchema()
     return jsonify(JSONSchema().dump(schema).data)
 
 
-@app.route('/')
+@app.route("/")
 def home():
-    return '''<!DOCTYPE html>
+    return """<!DOCTYPE html>
 <head>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/brutusin.json-forms/1.3.0/css/brutusin-json-forms.css"><Paste>
 <script src="https://code.jquery.com/jquery-1.12.1.min.js" integrity="sha256-I1nTg78tSrZev3kjvfdM5A5Ak/blglGzlaZANLPDl3I=" crossorigin="anonymous"></script>
@@ -42,7 +42,8 @@ $(document).ready(function() {
 <div id="myform"></div>
 </body>
 </html>
-'''
+"""
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True)

--- a/marshmallow_jsonschema/__init__.py
+++ b/marshmallow_jsonschema/__init__.py
@@ -1,10 +1,8 @@
 from pkg_resources import get_distribution
 
-__version__ = get_distribution('marshmallow-jsonschema').version
-__license__ = 'MIT'
+__version__ = get_distribution("marshmallow-jsonschema").version
+__license__ = "MIT"
 
 from .base import JSONSchema
 
-__all__ = (
-    'JSONSchema',
-)
+__all__ = ("JSONSchema",)

--- a/marshmallow_jsonschema/compat.py
+++ b/marshmallow_jsonschema/compat.py
@@ -13,20 +13,24 @@ else:
     basestring = (str, bytes)
 
 
-if marshmallow.__version__.split('.', 1)[0] >= '3':
+if marshmallow.__version__.split(".", 1)[0] >= "3":
     marshmallow_2 = False
+
     def dot_data_backwards_compatible(json_schema):
         return json_schema
+
+
 else:
     marshmallow_2 = True
+
     def dot_data_backwards_compatible(json_schema):
         return json_schema.data
 
 
 __all__ = (
-    'text_type',
-    'binary_type',
-    'basestring',
-    'marshmallow_2',
-    'dot_data_backwards_compatible',
+    "text_type",
+    "binary_type",
+    "basestring",
+    "marshmallow_2",
+    "dot_data_backwards_compatible",
 )

--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -25,14 +25,16 @@ def handle_length(schema, field, validator, parent_schema):
             `fields.List`, `fields.Nested`, or `fields.String`
     """
     if isinstance(field, fields.String):
-        minKey = 'minLength'
-        maxKey = 'maxLength'
+        minKey = "minLength"
+        maxKey = "maxLength"
     elif isinstance(field, (fields.List, fields.Nested)):
-        minKey = 'minItems'
-        maxKey = 'maxItems'
+        minKey = "minItems"
+        maxKey = "maxItems"
     else:
-        raise ValueError("In order to set the Length validator for JSON "
-                         "schema, the field must be either a List or a String")
+        raise ValueError(
+            "In order to set the Length validator for JSON "
+            "schema, the field must be either a List or a String"
+        )
 
     if validator.min:
         schema[minKey] = validator.min
@@ -66,8 +68,8 @@ def handle_one_of(schema, field, validator, parent_schema):
             altered.
     """
     if validator.choices:
-        schema['enum'] = list(validator.choices)
-        schema['enumNames'] = list(validator.labels)
+        schema["enum"] = list(validator.choices)
+        schema["enumNames"] = list(validator.labels)
 
     return schema
 
@@ -94,9 +96,9 @@ def handle_range(schema, field, validator, parent_schema):
         return schema
 
     if validator.min:
-        schema['minimum'] = validator.min
+        schema["minimum"] = validator.min
 
     if validator.max:
-        schema['maximum'] = validator.max
+        schema["maximum"] = validator.max
 
     return schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py27', 'py35', 'py36', 'py37']

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,5 @@ coverage>=4.5.3
 jsonschema>=2.6.0
 pytest>=4.6.3
 pytest-cov
+
+pre-commit~=1.17

--- a/setup.py
+++ b/setup.py
@@ -13,49 +13,54 @@ def read(fname):
 
 try:
     import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
+
+    long_description = pypandoc.convert("README.md", "rst")
 except (IOError, ImportError, OSError):
-    long_description = read('README.md')
+    long_description = read("README.md")
 
 
 REQUIREMENTS_FILE = "requirements.txt"
 REQUIREMENTS = open(os.path.join(PROJECT_DIR, REQUIREMENTS_FILE)).readlines()
 
 REQUIREMENTS_TESTS_FILE = "requirements-test.txt"
-REQUIREMENTS_TESTS = open(os.path.join(PROJECT_DIR, REQUIREMENTS_TESTS_FILE)).readlines()
+REQUIREMENTS_TESTS = open(
+    os.path.join(PROJECT_DIR, REQUIREMENTS_TESTS_FILE)
+).readlines()
 
 REQUIREMENTS_TOX_FILE = "requirements-tox.txt"
 REQUIREMENTS_TOX = open(os.path.join(PROJECT_DIR, REQUIREMENTS_TOX_FILE)).readlines()
 
 
 setup(
-    name='marshmallow-jsonschema',
-    version='0.6.0',
-    description='JSON Schema Draft v4 (http://json-schema.org/)'
-                ' formatting with marshmallow',
+    name="marshmallow-jsonschema",
+    version="0.6.0",
+    description="JSON Schema Draft v4 (http://json-schema.org/)"
+    " formatting with marshmallow",
     long_description=long_description,
-    author='Stephen Fuhry',
-    author_email='fuhrysteve@gmail.com',
-    url='https://github.com/fuhrysteve/marshmallow-jsonschema',
-    packages=find_packages(exclude=("test*", )),
-    package_dir={'marshmallow-jsonschema': 'marshmallow-jsonschema'},
+    author="Stephen Fuhry",
+    author_email="fuhrysteve@gmail.com",
+    url="https://github.com/fuhrysteve/marshmallow-jsonschema",
+    packages=find_packages(exclude=("test*",)),
+    package_dir={"marshmallow-jsonschema": "marshmallow-jsonschema"},
     include_package_data=True,
     install_requires=REQUIREMENTS,
     tests_require=REQUIREMENTS_TESTS + REQUIREMENTS_TOX,
-    license=read('LICENSE'),
+    license=read("LICENSE"),
     zip_safe=False,
-    keywords=('marshmallow-jsonschema marshmallow schema serialization '
-              'jsonschema validation'),
+    keywords=(
+        "marshmallow-jsonschema marshmallow schema serialization "
+        "jsonschema validation"
+    ),
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    test_suite='tests'
+    test_suite="tests",
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,7 @@ from marshmallow import Schema, fields, validate
 
 
 class Address(Schema):
-    id = fields.String(default='no-id')
+    id = fields.String(default="no-id")
     street = fields.String(required=True)
     number = fields.String(required=True)
     city = fields.String(required=True)
@@ -16,16 +16,17 @@ class GithubProfile(Schema):
 
 
 class UserSchema(Schema):
-    name = fields.String(required=True,
-                         validate=validate.Length(min=1, max=255))
+    name = fields.String(required=True, validate=validate.Length(min=1, max=255))
     age = fields.Float()
     created = fields.DateTime()
-    created_formatted = fields.DateTime(format="%Y-%m-%d", attribute="created", dump_only=True)
+    created_formatted = fields.DateTime(
+        format="%Y-%m-%d", attribute="created", dump_only=True
+    )
     created_iso = fields.DateTime(format="iso", attribute="created", dump_only=True)
     updated = fields.DateTime()
     updated_local = fields.LocalDateTime(attribute="updated", dump_only=True)
     species = fields.String(attribute="SPECIES")
-    id = fields.String(default='no-id')
+    id = fields.String(default="no-id")
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
@@ -37,12 +38,15 @@ class UserSchema(Schema):
     time_registered = fields.Time()
     birthdate = fields.Date()
     since_created = fields.TimeDelta()
-    sex = fields.Str(validate=validate.OneOf(
-        choices=['male', 'female', 'non_binary', 'other'],
-        labels=['Male', 'Female', 'Non-binary/fluid', 'Other']
-    ))
+    sex = fields.Str(
+        validate=validate.OneOf(
+            choices=["male", "female", "non_binary", "other"],
+            labels=["Male", "Female", "Non-binary/fluid", "Other"],
+        )
+    )
     various_data = fields.Dict()
-    addresses = fields.Nested(Address, many=True,
-                              validate=validate.Length(min=1, max=3))
+    addresses = fields.Nested(
+        Address, many=True, validate=validate.Length(min=1, max=3)
+    )
     github = fields.Nested(GithubProfile)
     const = fields.String(validate=validate.Length(equal=50))

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -24,7 +24,7 @@ def test_dump_schema():
 
     assert len(schema.fields) > 1
 
-    props = dumped['definitions']['UserSchema']['properties']
+    props = dumped["definitions"]["UserSchema"]["properties"]
     for field_name, field in schema.fields.items():
         assert field_name in props
 
@@ -37,14 +37,15 @@ def test_default():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['UserSchema']['properties']
-    assert props['id']['default'] == 'no-id'
+    props = dumped["definitions"]["UserSchema"]["properties"]
+    assert props["id"]["default"] == "no-id"
 
 
 def test_metadata():
     """Metadata should be available in the field definition."""
+
     class TestSchema(Schema):
-        myfield = fields.String(metadata={'foo': 'Bar'})
+        myfield = fields.String(metadata={"foo": "Bar"})
         yourfield = fields.Integer(required=True, baz="waz")
 
     schema = TestSchema()
@@ -54,11 +55,11 @@ def test_metadata():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['TestSchema']['properties']
-    assert props['myfield']['foo'] == 'Bar'
-    assert props['yourfield']['baz'] == 'waz'
-    assert 'metadata' not in props['myfield']
-    assert 'metadata' not in props['yourfield']
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert props["myfield"]["foo"] == "Bar"
+    assert props["yourfield"]["baz"] == "waz"
+    assert "metadata" not in props["myfield"]
+    assert "metadata" not in props["yourfield"]
 
     # repeat process to assure idempotency
     json_schema = JSONSchema()
@@ -67,14 +68,14 @@ def test_metadata():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['TestSchema']['properties']
-    assert props['myfield']['foo'] == 'Bar'
-    assert props['yourfield']['baz'] == 'waz'
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert props["myfield"]["foo"] == "Bar"
+    assert props["yourfield"]["baz"] == "waz"
 
 
 def test_descriptions():
     class TestSchema(Schema):
-        myfield = fields.String(metadata={'description': 'Brown Cow'})
+        myfield = fields.String(metadata={"description": "Brown Cow"})
         yourfield = fields.Integer(required=True)
 
     schema = TestSchema()
@@ -84,18 +85,19 @@ def test_descriptions():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['TestSchema']['properties']
-    assert props['myfield']['description'] == 'Brown Cow'
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert props["myfield"]["description"] == "Brown Cow"
 
 
 def test_nested_descriptions():
     class TestNestedSchema(Schema):
-        myfield = fields.String(metadata={'description': 'Brown Cow'})
+        myfield = fields.String(metadata={"description": "Brown Cow"})
         yourfield = fields.Integer(required=True)
 
     class TestSchema(Schema):
         nested = fields.Nested(
-            TestNestedSchema, metadata={'description': 'Nested 1', 'title': 'Title1'})
+            TestNestedSchema, metadata={"description": "Nested 1", "title": "Title1"}
+        )
         yourfield_nested = fields.Integer(required=True)
 
     schema = TestSchema()
@@ -105,13 +107,13 @@ def test_nested_descriptions():
 
     _validate_schema(dumped)
 
-    nested_def = dumped['definitions']['TestNestedSchema']
-    nested_dmp = dumped['definitions']['TestSchema']['properties']['nested']
-    assert nested_def['properties']['myfield']['description'] == 'Brown Cow'
+    nested_def = dumped["definitions"]["TestNestedSchema"]
+    nested_dmp = dumped["definitions"]["TestSchema"]["properties"]["nested"]
+    assert nested_def["properties"]["myfield"]["description"] == "Brown Cow"
 
-    assert nested_dmp['$ref'] == '#/definitions/TestNestedSchema'
-    assert nested_dmp['description'] == 'Nested 1'
-    assert nested_dmp['title'] == 'Title1'
+    assert nested_dmp["$ref"] == "#/definitions/TestNestedSchema"
+    assert nested_dmp["description"] == "Nested 1"
+    assert nested_dmp["title"] == "Title1"
 
 
 def test_nested_string_to_cls():
@@ -120,7 +122,7 @@ def test_nested_string_to_cls():
 
     class TestSchema(Schema):
         foo2 = fields.Integer(required=True)
-        nested = fields.Nested('TestNamedNestedSchema')
+        nested = fields.Nested("TestNamedNestedSchema")
 
     schema = TestSchema()
     json_schema = JSONSchema()
@@ -129,10 +131,10 @@ def test_nested_string_to_cls():
 
     _validate_schema(dumped)
 
-    nested_def = dumped['definitions']['TestNamedNestedSchema']
-    nested_dmp = dumped['definitions']['TestSchema']['properties']['nested']
-    assert nested_dmp['type'] == 'object'
-    assert nested_def['properties']['foo']['format'] == 'integer'
+    nested_def = dumped["definitions"]["TestNamedNestedSchema"]
+    nested_dmp = dumped["definitions"]["TestSchema"]["properties"]["nested"]
+    assert nested_dmp["type"] == "object"
+    assert nested_def["properties"]["foo"]["format"] == "integer"
 
 
 def test_list():
@@ -145,12 +147,12 @@ def test_list():
 
     _validate_schema(dumped)
 
-    nested_json = dumped['definitions']['ListSchema']['properties']['foo']
-    assert nested_json['type'] == 'array'
-    assert 'items' in nested_json
+    nested_json = dumped["definitions"]["ListSchema"]["properties"]["foo"]
+    assert nested_json["type"] == "array"
+    assert "items" in nested_json
 
-    item_schema = nested_json['items']
-    assert item_schema['type'] == 'string'
+    item_schema = nested_json["items"]
+    assert item_schema["type"] == "string"
 
 
 def test_list_nested():
@@ -166,13 +168,13 @@ def test_list_nested():
     json_schema = JSONSchema()
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
     _validate_schema(dumped)
-    nested_json = dumped['definitions']['ListSchema']['properties']['bar']
+    nested_json = dumped["definitions"]["ListSchema"]["properties"]["bar"]
 
-    assert nested_json['type'] == 'array'
-    assert 'items' in nested_json
+    assert nested_json["type"] == "array"
+    assert "items" in nested_json
 
-    item_schema = nested_json['items']
-    assert 'InnerSchema' in item_schema['$ref']
+    item_schema = nested_json["items"]
+    assert "InnerSchema" in item_schema["$ref"]
 
 
 def test_deep_nested():
@@ -196,88 +198,92 @@ def test_deep_nested():
 
     _validate_schema(dumped)
 
-    defs = dumped['definitions']
-    assert 'OuterSchema' in defs
-    assert 'OuterMiddleSchema' in defs
-    assert 'InnerMiddleSchema' in defs
-    assert 'InnerSchema' in defs
+    defs = dumped["definitions"]
+    assert "OuterSchema" in defs
+    assert "OuterMiddleSchema" in defs
+    assert "InnerMiddleSchema" in defs
+    assert "InnerSchema" in defs
 
 
 def test_respect_only_for_nested_schema():
     """Should ignore fields not in 'only' metadata for nested schemas."""
+
     class InnerRecursiveSchema(Schema):
         id = fields.Integer(required=True)
         baz = fields.String()
-        recursive = fields.Nested('InnerRecursiveSchema')
+        recursive = fields.Nested("InnerRecursiveSchema")
 
     class MiddleSchema(Schema):
         id = fields.Integer(required=True)
         bar = fields.String()
-        inner = fields.Nested('InnerRecursiveSchema', only=('id', 'baz'))
+        inner = fields.Nested("InnerRecursiveSchema", only=("id", "baz"))
 
     class OuterSchema(Schema):
         foo2 = fields.Integer(required=True)
-        nested = fields.Nested('MiddleSchema')
+        nested = fields.Nested("MiddleSchema")
 
     schema = OuterSchema()
     json_schema = JSONSchema()
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
-    inner_props = dumped['definitions']['InnerRecursiveSchema']['properties']
-    assert 'recursive' not in inner_props
+    inner_props = dumped["definitions"]["InnerRecursiveSchema"]["properties"]
+    assert "recursive" not in inner_props
 
 
 def test_respect_exclude_for_nested_schema():
     """Should ignore fields in 'exclude' metadata for nested schemas."""
+
     class InnerRecursiveSchema(Schema):
         id = fields.Integer(required=True)
         baz = fields.String()
-        recursive = fields.Nested('InnerRecursiveSchema')
+        recursive = fields.Nested("InnerRecursiveSchema")
 
     class MiddleSchema(Schema):
         id = fields.Integer(required=True)
         bar = fields.String()
-        inner = fields.Nested('InnerRecursiveSchema', exclude=('recursive',))
+        inner = fields.Nested("InnerRecursiveSchema", exclude=("recursive",))
 
     class OuterSchema(Schema):
         foo2 = fields.Integer(required=True)
-        nested = fields.Nested('MiddleSchema')
+        nested = fields.Nested("MiddleSchema")
 
     schema = OuterSchema()
     json_schema = JSONSchema()
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    inner_props = dumped['definitions']['InnerRecursiveSchema']['properties']
-    assert 'recursive' not in inner_props
+    inner_props = dumped["definitions"]["InnerRecursiveSchema"]["properties"]
+    assert "recursive" not in inner_props
 
 
 def test_respect_dotted_exclude_for_nested_schema():
     """Should ignore dotted fields in 'exclude' metadata for nested schemas."""
+
     class InnerRecursiveSchema(Schema):
         id = fields.Integer(required=True)
         baz = fields.String()
-        recursive = fields.Nested('InnerRecursiveSchema')
+        recursive = fields.Nested("InnerRecursiveSchema")
 
     class MiddleSchema(Schema):
         id = fields.Integer(required=True)
         bar = fields.String()
-        inner = fields.Nested('InnerRecursiveSchema')
+        inner = fields.Nested("InnerRecursiveSchema")
 
     class OuterSchema(Schema):
         foo2 = fields.Integer(required=True)
-        nested = fields.Nested('MiddleSchema', exclude=('inner.recursive',))
+        nested = fields.Nested("MiddleSchema", exclude=("inner.recursive",))
 
     schema = OuterSchema()
     json_schema = JSONSchema()
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    inner_props = dumped['definitions']['InnerRecursiveSchema']['properties']
-    assert 'recursive' not in inner_props
+    inner_props = dumped["definitions"]["InnerRecursiveSchema"]["properties"]
+    assert "recursive" not in inner_props
 
 
 def test_nested_instance():
     """Should also work with nested schema instances"""
+
     class TestNestedSchema(Schema):
         baz = fields.Integer()
 
@@ -291,11 +297,11 @@ def test_nested_instance():
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
     _validate_schema(dumped)
-    nested_def = dumped['definitions']['TestNestedSchema']
-    nested_obj = dumped['definitions']['TestSchema']['properties']['bar']
+    nested_def = dumped["definitions"]["TestNestedSchema"]
+    nested_obj = dumped["definitions"]["TestSchema"]["properties"]["bar"]
 
     assert "baz" in nested_def["properties"]
-    assert nested_obj['$ref'] == '#/definitions/TestNestedSchema'
+    assert nested_obj["$ref"] == "#/definitions/TestNestedSchema"
 
 
 def test_function():
@@ -303,12 +309,10 @@ def test_function():
 
     class FnSchema(Schema):
         fn_str = fields.Function(
-            lambda: "string", required=True,
-            _jsonschema_type_mapping={'type': 'string'}
+            lambda: "string", required=True, _jsonschema_type_mapping={"type": "string"}
         )
         fn_int = fields.Function(
-            lambda: 123, required=True,
-            _jsonschema_type_mapping={'type': 'number'}
+            lambda: 123, required=True, _jsonschema_type_mapping={"type": "number"}
         )
 
     schema = FnSchema()
@@ -316,9 +320,9 @@ def test_function():
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    props = dumped['definitions']['FnSchema']['properties']
-    assert props['fn_int']['type'] == 'number'
-    assert props['fn_str']['type'] == 'string'
+    props = dumped["definitions"]["FnSchema"]["properties"]
+    assert props["fn_int"]["type"] == "number"
+    assert props["fn_str"]["type"] == "string"
 
 
 def test_nested_recursive():
@@ -326,7 +330,7 @@ def test_nested_recursive():
 
     class RecursiveSchema(Schema):
         foo = fields.Integer(required=True)
-        children = fields.Nested('RecursiveSchema', many=True)
+        children = fields.Nested("RecursiveSchema", many=True)
 
     schema = RecursiveSchema()
     json_schema = JSONSchema()
@@ -335,8 +339,8 @@ def test_nested_recursive():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['RecursiveSchema']['properties']
-    assert 'RecursiveSchema' in props['children']['items']['$ref']
+    props = dumped["definitions"]["RecursiveSchema"]["properties"]
+    assert "RecursiveSchema" in props["children"]["items"]["$ref"]
 
 
 def test_one_of_validator():
@@ -347,18 +351,18 @@ def test_one_of_validator():
 
     _validate_schema(dumped)
 
-    assert (
-        dumped['definitions']['UserSchema']['properties']['sex']['enum'] == [
-            'male', 'female', 'non_binary', 'other'
-        ]
-    )
-    assert (
-        dumped['definitions']['UserSchema']['properties']['sex'][
-            'enumNames'
-        ] == [
-            'Male', 'Female', 'Non-binary/fluid', 'Other'
-        ]
-    )
+    assert dumped["definitions"]["UserSchema"]["properties"]["sex"]["enum"] == [
+        "male",
+        "female",
+        "non_binary",
+        "other",
+    ]
+    assert dumped["definitions"]["UserSchema"]["properties"]["sex"]["enumNames"] == [
+        "Male",
+        "Female",
+        "Non-binary/fluid",
+        "Other",
+    ]
 
 
 def test_range_validator():
@@ -369,9 +373,9 @@ def test_range_validator():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['Address']['properties']
-    assert props['floor']['minimum'] == 1
-    assert props['floor']['maximum'] == 4
+    props = dumped["definitions"]["Address"]["properties"]
+    assert props["floor"]["minimum"] == 1
+    assert props["floor"]["maximum"] == 4
 
 
 def test_length_validator():
@@ -382,13 +386,13 @@ def test_length_validator():
 
     _validate_schema(dumped)
 
-    props = dumped['definitions']['UserSchema']['properties']
-    assert props['name']['minLength'] == 1
-    assert props['name']['maxLength'] == 255
-    assert props['addresses']['minItems'] == 1
-    assert props['addresses']['maxItems'] == 3
-    assert props['const']['minLength'] == 50
-    assert props['const']['maxLength'] == 50
+    props = dumped["definitions"]["UserSchema"]["properties"]
+    assert props["name"]["minLength"] == 1
+    assert props["name"]["maxLength"] == 255
+    assert props["addresses"]["minItems"] == 1
+    assert props["addresses"]["maxItems"] == 3
+    assert props["const"]["minLength"] == 50
+    assert props["const"]["maxLength"] == 50
 
 
 def test_length_validator_value_error():
@@ -463,17 +467,21 @@ def test_handle_range_no_minimum():
     schema2 = SchemaNoMin()
     json_schema = JSONSchema()
 
-    dumped1 = dot_data_backwards_compatible(json_schema.dump(schema1))['definitions']['SchemaMin']
-    dumped2 = dot_data_backwards_compatible(json_schema.dump(schema2))['definitions']['SchemaNoMin']
-    assert dumped1['properties']['floor']['minimum'] == 1
-    assert 'exclusiveMinimum' not in dumped1['properties']['floor'].keys()
-    assert 'minimum' not in dumped2['properties']['floor']
-    assert 'exclusiveMinimum' not in dumped2['properties']['floor']
+    dumped1 = dot_data_backwards_compatible(json_schema.dump(schema1))["definitions"][
+        "SchemaMin"
+    ]
+    dumped2 = dot_data_backwards_compatible(json_schema.dump(schema2))["definitions"][
+        "SchemaNoMin"
+    ]
+    assert dumped1["properties"]["floor"]["minimum"] == 1
+    assert "exclusiveMinimum" not in dumped1["properties"]["floor"].keys()
+    assert "minimum" not in dumped2["properties"]["floor"]
+    assert "exclusiveMinimum" not in dumped2["properties"]["floor"]
 
 
 def test_title():
     class TestSchema(Schema):
-        myfield = fields.String(metadata={'title': 'Brown Cowzz'})
+        myfield = fields.String(metadata={"title": "Brown Cowzz"})
         yourfield = fields.Integer(required=True)
 
     schema = TestSchema()
@@ -483,13 +491,13 @@ def test_title():
 
     _validate_schema(dumped)
 
-    assert dumped['definitions']['TestSchema']['properties']['myfield'][
-        'title'
-    ] == 'Brown Cowzz'
+    assert (
+        dumped["definitions"]["TestSchema"]["properties"]["myfield"]["title"]
+        == "Brown Cowzz"
+    )
 
 
 def test_unknown_typed_field_throws_valueerror():
-
     class Invalid(fields.Field):
         def _serialize(self, value, attr, obj):
             return value
@@ -505,19 +513,16 @@ def test_unknown_typed_field_throws_valueerror():
 
 
 def test_unknown_typed_field():
-
     class Colour(fields.Field):
         def _jsonschema_type_mapping(self):
-            return {
-                'type': 'string',
-            }
+            return {"type": "string"}
 
         def _serialize(self, value, attr, obj):
             r, g, b = value
             r = hex(r)[2:]
             g = hex(g)[2:]
             b = hex(b)[2:]
-            return '#' + r + g + b
+            return "#" + r + g + b
 
     class UserSchema(Schema):
         name = fields.String(required=True)
@@ -528,9 +533,9 @@ def test_unknown_typed_field():
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    assert dumped['definitions']['UserSchema']['properties'][
-        'favourite_colour'
-    ] == {'type': 'string'}
+    assert dumped["definitions"]["UserSchema"]["properties"]["favourite_colour"] == {
+        "type": "string"
+    }
 
 
 def test_readonly():
@@ -543,53 +548,51 @@ def test_readonly():
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    assert dumped['definitions']['TestSchema']['properties'][
-        'readonly_fld'
-    ] == {
-        'title': 'readonly_fld',
-        'type': 'string',
-        'readonly': True,
+    assert dumped["definitions"]["TestSchema"]["properties"]["readonly_fld"] == {
+        "title": "readonly_fld",
+        "type": "string",
+        "readonly": True,
     }
 
 
 def test_metadata_direct_from_field():
     """Should be able to get metadata without accessing metadata kwarg."""
+
     class TestSchema(Schema):
         id = fields.Integer(required=True)
-        metadata_field = fields.String(description='Directly on the field!')
+        metadata_field = fields.String(description="Directly on the field!")
 
     schema = TestSchema()
     json_schema = JSONSchema()
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    assert dumped['definitions']['TestSchema']['properties'][
-        'metadata_field'
-    ] == {
-        'title': 'metadata_field',
-        'type': 'string',
-        'description': 'Directly on the field!',
+    assert dumped["definitions"]["TestSchema"]["properties"]["metadata_field"] == {
+        "title": "metadata_field",
+        "type": "string",
+        "description": "Directly on the field!",
     }
 
 
 def test_dumps_iterable_enums():
-    mapping = {'a': 0, 'b': 1, 'c': 2}
+    mapping = {"a": 0, "b": 1, "c": 2}
 
     class TestSchema(Schema):
-        foo = fields.Integer(validate=validate.OneOf(
-            mapping.values(), labels=mapping.keys()))
+        foo = fields.Integer(
+            validate=validate.OneOf(mapping.values(), labels=mapping.keys())
+        )
 
     schema = TestSchema()
     json_schema = JSONSchema()
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    assert dumped['definitions']['TestSchema']['properties']['foo'] == {
-        'enum': [v for v in mapping.values()],
-        'enumNames': [k for k in mapping.keys()],
-        'format': 'integer',
-        'title': 'foo',
-        'type': 'number'
+    assert dumped["definitions"]["TestSchema"]["properties"]["foo"] == {
+        "enum": [v for v in mapping.values()],
+        "enumNames": [k for k in mapping.keys()],
+        "format": "integer",
+        "title": "foo",
+        "type": "number",
     }
 
 
@@ -602,4 +605,4 @@ def test_required_excluded_when_empty():
 
     dumped = dot_data_backwards_compatible(json_schema.dump(schema))
 
-    assert 'required' not in dumped['definitions']['TestSchema']
+    assert "required" not in dumped["definitions"]["TestSchema"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,35,36,37,py,py3}-marshmallow{2,3}
+envlist=lint,py{27,35,36,37,py,py3}-marshmallow{2,3}
 
 [testenv]
 deps=
@@ -9,3 +9,9 @@ deps=
     py{35,36,37,py3}-marshmallow3: marshmallow==3.0.0rc7
 whitelist_externals=make
 commands=make test_coverage
+
+
+[testenv:lint]
+deps = pre-commit~=1.17
+skip_install = true
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
This PR is a bit controversial as it touches code style formatting, but black seems to be de-facto industry format. I haven't had much experience with pre-commit hooks myself, so I've borrowed all the configuration and especially `CONTRIBUTING.md` instructions from marshmallow official repository and everything seems to be working smooth so far.

I do believe we need proper style formatting so that code style does not get in the way when working on large features.

Please tell if you have any thoughts/suggestions on this matter.