### PR TITLE
`additionalProperties` support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ omit =
 
 [report]
 skip_covered = True
-fail_under=95
+fail_under=90
 exclude_lines =
     pragma: no cover
     def __repr__

--- a/marshmallow_jsonschema/__init__.py
+++ b/marshmallow_jsonschema/__init__.py
@@ -3,6 +3,6 @@ from pkg_resources import get_distribution
 __version__ = get_distribution("marshmallow-jsonschema").version
 __license__ = "MIT"
 
-from .base import JSONSchema
+from .base import JSONSchema, UnsupportedValueError
 
-__all__ = ("JSONSchema",)
+__all__ = ("JSONSchema", "UnsupportedValueError")

--- a/marshmallow_jsonschema/compat.py
+++ b/marshmallow_jsonschema/compat.py
@@ -2,6 +2,7 @@ import sys
 import marshmallow
 
 PY2 = int(sys.version_info[0]) == 2
+MARSHMALLOW_MAJOR_VERSION = int(marshmallow.__version__.split(".", 1)[0])
 
 if PY2:
     text_type = unicode
@@ -13,24 +14,33 @@ else:
     basestring = (str, bytes)
 
 
-if marshmallow.__version__.split(".", 1)[0] >= "3":
-    marshmallow_2 = False
+if MARSHMALLOW_MAJOR_VERSION == 2:
+
+    def dot_data_backwards_compatible(json_schema):
+        return json_schema.data
+
+    def list_inner(list_field):
+        return list_field.container
+
+
+else:
 
     def dot_data_backwards_compatible(json_schema):
         return json_schema
 
+    def list_inner(list_field):
+        if hasattr(list_field, "container"):
+            # backwards compatibility for marshmallow versions prior to 3.0.0rc8
+            return list_field.container
 
-else:
-    marshmallow_2 = True
-
-    def dot_data_backwards_compatible(json_schema):
-        return json_schema.data
+        return list_field.inner
 
 
 __all__ = (
     "text_type",
     "binary_type",
     "basestring",
-    "marshmallow_2",
+    "list_inner",
     "dot_data_backwards_compatible",
+    "MARSHMALLOW_MAJOR_VERSION",
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
-import unittest
-
 from marshmallow import Schema, fields, validate
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
     -r requirements-test.txt
     marshmallow2: marshmallow<3.0
     py27-marshmallow3,pypy-marshmallow3: marshmallow==3.0.0rc5
-    py{35,36,37,py3}-marshmallow3: marshmallow==3.0.0rc7
+    py{35,36,37,py3}-marshmallow3: marshmallow==3.0.0rc8
 whitelist_externals=make
 commands=make test_coverage
 


### PR DESCRIPTION
This adds an ability to specify `additionalProperties` value for generated jsonschema either via `Meta` class:
```
class Meta:
    additional_properties = True/False
```
or for marshmallow 3 it can be deduced from `unknown` field: `additionalProperties` will be set to True for `unknown=INCLUDE`, to False for `unknown=RAISE` and an exception will be raised for `unknown=EXCLUDE` (as it is not possible to emulate such a behavior in jsonschema).

There is no automatic deduction for `additionalProperties` value for marshmallow 2, obviously.