### PR TITLE
Get pytype by checking field's subclass

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -168,7 +168,6 @@ class JSONSchema(Schema):
                 schema = getattr(self, pytype)(obj, field)
             else:
                 schema = self._from_python_type(obj, field, pytype)
-            
         # Apply any and all validators that field may have
         for validator in field.validators:
             if validator.__class__ in FIELD_VALIDATORS:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -148,6 +148,13 @@ class JSONSchema(Schema):
             json_schema["items"] = self._get_schema_for_field(obj, list_inner(field))
         return json_schema
 
+    def _get_pytype(self, field_class, mapping):
+        """Get pytype based on field subclass"""
+        for map_class, pytype in mapping.items():
+            if issubclass(field_class, map_class):
+                return pytype
+        return None
+
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
         mapping = self._get_default_mapping(obj)
@@ -155,15 +162,15 @@ class JSONSchema(Schema):
             schema = field._jsonschema_type_mapping()
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
-        elif field.__class__ in mapping:
-            pytype = mapping[field.__class__]
+        else:
+            pytype = self._get_pytype(field.__class__, mapping)
+            if not pytype:
+                raise UnsupportedValueError("unsupported field type %s" % field)
             if isinstance(pytype, basestring):
                 schema = getattr(self, pytype)(obj, field)
             else:
                 schema = self._from_python_type(obj, field, pytype)
-        else:
-            raise UnsupportedValueError("unsupported field type %s" % field)
-
+            
         # Apply any and all validators that field may have
         for validator in field.validators:
             if validator.__class__ in FIELD_VALIDATORS:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -148,12 +148,12 @@ class JSONSchema(Schema):
             json_schema["items"] = self._get_schema_for_field(obj, list_inner(field))
         return json_schema
 
-    def _get_pytype(self, field_class, mapping):
+    def _get_pytype(self, field, mapping):
         """Get pytype based on field subclass"""
         for map_class, pytype in mapping.items():
-            if issubclass(field_class, map_class):
+            if issubclass(field.__class__, map_class):
                 return pytype
-        return None
+        raise UnsupportedValueError("unsupported field type %s" % field)
 
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
@@ -163,9 +163,7 @@ class JSONSchema(Schema):
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
         else:
-            pytype = self._get_pytype(field.__class__, mapping)
-            if not pytype:
-                raise UnsupportedValueError("unsupported field type %s" % field)
+            pytype = self._get_pytype(field, mapping)
             if isinstance(pytype, basestring):
                 schema = getattr(self, pytype)(obj, field)
             else:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -355,8 +355,7 @@ def test_field_subclass():
     """JSON schema generation should not fail on sublcass marshmallow field."""
 
     class CustomString(fields.String):
-        def __init__(self, *args, **kwargs):
-            super().__init__(**kwargs)
+        pass
 
     class TestSchema(Schema):
         myfield = CustomString()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -354,17 +354,15 @@ def test_unknown_typed_field():
 def test_field_subclass():
     """JSON schema generation should not fail on sublcass marshmallow field."""
 
-    class CustomString(fields.String):
+    class CustomField(fields.Field):
         pass
 
     class TestSchema(Schema):
-        myfield = CustomString()
+        myfield = CustomField()
 
     schema = TestSchema()
-    try:
+    with pytest.raises(UnsupportedValueError):
         _ = validate_and_dump(schema)
-    except UnsupportedValueError:
-        pytest.fail("JSON schema generation raised UnsupportedValueError")
 
 
 def test_readonly():

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -351,6 +351,23 @@ def test_unknown_typed_field():
     }
 
 
+def test_field_subclass():
+    """JSON schema generation should not fail on sublcass marshmallow field."""
+
+    class CustomString(fields.String):
+        def __init__(self, *args, **kwargs):
+            super().__init__(**kwargs)
+
+    class TestSchema(Schema):
+        myfield = CustomString()
+
+    schema = TestSchema()
+    try:
+        _ = validate_and_dump(schema)
+    except UnsupportedValueError:
+        pytest.fail("JSON schema generation raised UnsupportedValueError")
+
+
 def test_readonly():
     class TestSchema(Schema):
         id = fields.Integer(required=True)


### PR DESCRIPTION
Addresses #79 

Instead of simply running field's class against `mapping` keys, check whether field's class is a subclass of one of the `mapping` keys.