### PR TITLE
Add support for marshmallow.fields.Number

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -98,6 +98,7 @@ class JSONSchema(Schema):
                 fields.List: list,
                 fields.LocalDateTime: datetime.datetime,
                 fields.Nested: "_from_nested_schema",
+                fields.Number: decimal.Decimal,
             }
         )
         return mapping


### PR DESCRIPTION
Addresses: #85 

Extends default mapping with an entry `marshmallow.fields.Number: decimal.Decimal`