### PR TITLE
Introduce ability to modify JSON schema property name

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -108,7 +108,7 @@ class JSONSchema(Schema):
 
         for field_name, field in sorted(obj.fields.items()):
             schema = self._get_schema_for_field(obj, field)
-            properties[field.name] = schema
+            properties[field.metadata.get('name') or field.name] = schema
 
         return properties
 
@@ -140,7 +140,7 @@ class JSONSchema(Schema):
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
-            if md_key == "metadata":
+            if md_key in  ("metadata", "name"):
                 continue
             json_schema[md_key] = md_val
 
@@ -219,7 +219,7 @@ class JSONSchema(Schema):
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
-            if md_key == "metadata":
+            if md_key in ("metadata", "name"):
                 continue
             schema[md_key] = md_val
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -108,7 +108,7 @@ class JSONSchema(Schema):
 
         for field_name, field in sorted(obj.fields.items()):
             schema = self._get_schema_for_field(obj, field)
-            properties[field.metadata.get('name') or field.name] = schema
+            properties[field.metadata.get("name") or field.name] = schema
 
         return properties
 
@@ -140,7 +140,7 @@ class JSONSchema(Schema):
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
-            if md_key in  ("metadata", "name"):
+            if md_key in ("metadata", "name"):
                 continue
             json_schema[md_key] = md_val
 


### PR DESCRIPTION
Addresses #83

Now, a user has an ability to modify JSON schema property name using `metadata['name']` parameter.

Ex., consider the following schema:
```
class ExampleSchema(Schema):
    api_token = String(description='API token.')
```
Resulting JSON schema would look like this:
```
{
    "$ref": "#/definitions/ExampleSchema",
    "$schema": "http://json-schema.org/draft-07/schema#",
    "definitions": {
        "ExampleSchema": {
            "additionalProperties": false,
            "properties": {
                "api_token": {
                    "description": "API token.",
                    "title": "api_token",
                    "type": "string"
                }
            },
            "type": "object"
        }
    }
}
```

If a user desires to modify JSON schema property name (the part `"api_token": {`), one can simply add `name` parameter to the schema:
```
class ExampleSchema(Schema):
    api_token = String(name='api-token', description='API token.')
```

Which will yield:
```
{
    "$ref": "#/definitions/ExampleSchema",
    "$schema": "http://json-schema.org/draft-07/schema#",
    "definitions": {
        "ExampleSchema": {
            "additionalProperties": false,
            "properties": {
                "api-token": { <- used metadata['name']
                    "description": "API token.",
                    "title": "api_token",
                    "type": "string"
                }
            },
            "type": "object"
        }
    }
}
```