### PR TITLE
Quick fix for marshmallow 3.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+.reports/
+.pytest_cache/
 htmlcov/
 .tox/
 .coverage

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -96,7 +96,7 @@ class JSONSchema(Schema):
                 fields.Dict: dict,
                 fields.Url: text_type,
                 fields.List: list,
-                fields.LocalDateTime: datetime.datetime,
+                fields.DateTime: datetime.datetime,
                 fields.Nested: "_from_nested_schema",
                 fields.Number: decimal.Decimal,
             }


### PR DESCRIPTION
`fields.LocalDateTime` was removed in marshmallow 3.0.0rc9 [(see link)](https://marshmallow.readthedocs.io/en/latest/changelog.html?highlight=LocalDateTime#rc9-2019-07-31), I just changed it to `fields.DateTime`.

I'm not going to pretend like I thoroughly checked the implications thought ...

Fixes #84 