### PR TITLE
Skip title if either fields are None

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -158,7 +158,7 @@ class JSONSchema(Schema):
         if field.attribute or field.name:
             json_schema["title"] = field.attribute or field.name
 
-        for key, val in TYPE_MAP[pytype].items():
+        for key, val in PY_TO_JSON_TYPES_MAP[pytype].items():
             json_schema[key] = val
 
         if field.dump_only:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -153,9 +153,12 @@ class JSONSchema(Schema):
 
     def _from_python_type(self, obj, field, pytype):
         """Get schema definition from python type."""
-        json_schema = {"title": field.attribute or field.name}
-
-        for key, val in PY_TO_JSON_TYPES_MAP[pytype].items():
+        json_schema = {}
+        
+        if field.attribute or field.name:
+            json_schema["title"] = field.attribute or field.name
+        
+        for key, val in TYPE_MAP[pytype].items():
             json_schema[key] = val
 
         if field.dump_only:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -154,10 +154,10 @@ class JSONSchema(Schema):
     def _from_python_type(self, obj, field, pytype):
         """Get schema definition from python type."""
         json_schema = {}
-        
+
         if field.attribute or field.name:
             json_schema["title"] = field.attribute or field.name
-        
+
         for key, val in TYPE_MAP[pytype].items():
             json_schema[key] = val
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -80,6 +80,21 @@ def test_range_marshmallow_2():
     assert props["foo"]["minimum"] == 1
     assert props["foo"]["maximum"] == 3
 
+@pytest.mark.skipif(MARSHMALLOW_3, reason="fixed in marshmallow 3")
+def test_doubly_nested_skipped_titles():
+    class TestSchema(Schema):
+        foo = fields.List(fields.List(fields.Integer()))
+    
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    props = dumped["definitions"]["TestSchema"]["properties"]
+
+    assert props["foo"]["title"] == "foo"
+    assert props["foo"]["items"]["title"] == "foo"
+    with pytest.raises(KeyError):
+        props["foo"]["items"]["items"]["title"]
 
 @pytest.mark.skipif(MARSHMALLOW_2, reason="marshmallow 3 only")
 def test_range_marshmallow_3():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -80,11 +80,12 @@ def test_range_marshmallow_2():
     assert props["foo"]["minimum"] == 1
     assert props["foo"]["maximum"] == 3
 
+
 @pytest.mark.skipif(MARSHMALLOW_3, reason="fixed in marshmallow 3")
 def test_doubly_nested_skipped_titles():
     class TestSchema(Schema):
         foo = fields.List(fields.List(fields.Integer()))
-    
+
     schema = TestSchema()
 
     dumped = validate_and_dump(schema)
@@ -95,6 +96,7 @@ def test_doubly_nested_skipped_titles():
     assert props["foo"]["items"]["title"] == "foo"
     with pytest.raises(KeyError):
         props["foo"]["items"]["items"]["title"]
+
 
 @pytest.mark.skipif(MARSHMALLOW_2, reason="marshmallow 3 only")
 def test_range_marshmallow_3():


### PR DESCRIPTION
Addresses #87

Because of lack of support of doubly (or more) nested schemas, some `title`s get rendered as `null` which breaks JSON schema validation. This PR simply skips `title` if `field.attribute` or `field.name` are `None`