### PR TITLE
fix: get_properties no longer sorts keys in alphabetical order

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -151,7 +151,7 @@ class JSONSchema(Schema):
 
     def get_properties(self, obj) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
         """Fill out properties field."""
-        properties = self.dict_class()
+        properties = obj.dict_class()
 
         if self.props_ordered:
             fields_items_sequence = obj.fields.items()


### PR DESCRIPTION
The `get_properties` method sorts the properties in alphabetical order. If the schema defines a `Meta` schema like the one below, the properties will most likely be in the wrong order

```python
class Meta:
    ordered = True
```