### PR TITLE
feat(validation): add anyOf validator for ContainsOnly

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -31,6 +31,7 @@ from .validation import (
     handle_equal,
     handle_length,
     handle_one_of,
+    handle_any_of,
     handle_range,
     handle_regexp,
 )
@@ -100,6 +101,7 @@ FIELD_VALIDATORS = {
     validate.Equal: handle_equal,
     validate.Length: handle_length,
     validate.OneOf: handle_one_of,
+    validate.ContainsOnly: handle_any_of,
     validate.Range: handle_range,
     validate.Regexp: handle_regexp,
 }


### PR DESCRIPTION
Just like the `OneOf` validator, the `ContainsOnly` validator can be used to generate a JSON schema that validates a list of items. This PR adds the `anyOf` property to the schema if it is using the `ContainsOnly` validator on a list of items