### PR TITLE
fix: use data_key from field if available to set property name

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -160,7 +160,7 @@ class JSONSchema(Schema):
 
         for field_name, field in fields_items_sequence:
             schema = self._get_schema_for_field(obj, field)
-            properties[field.metadata.get("name") or field.name] = schema
+            properties[field.data_key or field.name] = schema
 
         return properties
 
@@ -199,7 +199,7 @@ class JSONSchema(Schema):
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
-            if md_key in ("metadata", "name"):
+            if md_key == "metadata":
                 continue
             json_schema[md_key] = md_val
 
@@ -317,7 +317,7 @@ class JSONSchema(Schema):
         metadata.update(field.metadata)
 
         for md_key, md_val in metadata.items():
-            if md_key in ("metadata", "name"):
+            if md_key == "metadata":
                 continue
             schema[md_key] = md_val
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -170,7 +170,7 @@ class JSONSchema(Schema):
 
         for field_name, field in sorted(obj.fields.items()):
             if field.required:
-                required.append(field.name)
+                required.append(field.data_key or field.name)
 
         return required or missing
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,7 +32,7 @@ class UserSchema(Schema):
     email = fields.Email()
     balance = fields.Decimal()
     registered = fields.Boolean()
-    hair_colors = fields.List(fields.Raw)
+    hair_colors = fields.List(fields.Raw, data_key="hairColors", required=True)
     sex_choices = fields.List(fields.Raw)
     finger_count = fields.Integer()
     uid = fields.UUID()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -18,7 +18,7 @@ def test_dump_schema():
 
     props = dumped["definitions"]["UserSchema"]["properties"]
     for field_name, field in schema.fields.items():
-        assert field_name in props
+        assert field.data_key or field_name in props
 
 
 def test_default():


### PR DESCRIPTION
#88 introduced the ability to customize the name of the fields when serializing, which is great! However, Marshmallow already has a way to customize the name of fields when serializing through the `data_key` property. The JSONSchema should use the same property when serializing the schema to json instead of inventing its own thing.