### PR TITLE
Fixed marshmallow type subclass check for datetime based classes, added few simple additional options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ ENV/
 .spyderproject
 .spyproject
 
+# Vscode project settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -112,7 +112,7 @@ class JSONSchema(Schema):
     type = fields.Constant("object")
     required = fields.Method("get_required")
 
-    def __init__(self, *args, props_ordered=False, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Setup internal cache of nested fields, to prevent recursion.
 
         :param bool props_ordered: if `True` order of properties will be save as declare in class,
@@ -122,7 +122,7 @@ class JSONSchema(Schema):
         """
         self._nested_schema_classes = {}
         self.nested = kwargs.pop("nested", False)
-        self.props_ordered = props_ordered
+        self.props_ordered = kwargs.pop("props_ordered", False)
         super(JSONSchema, self).__init__(*args, **kwargs)
 
     def get_properties(self, obj):

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -123,11 +123,12 @@ class JSONSchema(Schema):
         self._nested_schema_classes = {}
         self.nested = kwargs.pop("nested", False)
         self.props_ordered = kwargs.pop("props_ordered", False)
+        setattr(self.opts, "ordered", self.props_ordered)
         super(JSONSchema, self).__init__(*args, **kwargs)
 
     def get_properties(self, obj):
         """Fill out properties field."""
-        properties = {}
+        properties = self.dict_class()
 
         if self.props_ordered:
             fields_items_sequence = obj.fields.items()

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -52,7 +52,6 @@ MARSHMALLOW_TO_PY_TYPES_PAIRS = (
     # This part of a mapping is carefully selected from marshmallow source code,
     # see marshmallow.BaseSchema.TYPE_MAPPING.
     (fields.String, text_type),
-    (fields.DateTime, datetime.datetime),
     (fields.Float, float),
     (fields.Raw, text_type),
     (fields.Boolean, bool),
@@ -61,6 +60,7 @@ MARSHMALLOW_TO_PY_TYPES_PAIRS = (
     (fields.Time, datetime.time),
     (fields.Date, datetime.date),
     (fields.TimeDelta, datetime.timedelta),
+    (fields.DateTime, datetime.datetime),
     (fields.Decimal, decimal.Decimal),
     # These are some mappings that generally make sense for the rest
     # of marshmallow fields.

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -200,10 +200,9 @@ class JSONSchema(Schema):
                 schema = self._from_python_type(obj, field, pytype)
         # Apply any and all validators that field may have
         for validator in field.validators:
-            if validator.__class__ in FIELD_VALIDATORS:
-                schema = FIELD_VALIDATORS[validator.__class__](
-                    schema, field, validator, obj
-                )
+            for map_class, map_handler in FIELD_VALIDATORS.items():
+                if issubclass(validator.__class__, map_class):
+                    schema = map_handler(schema, field, validator, obj)
         return schema
 
     def _from_nested_schema(self, obj, field):

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -18,8 +18,7 @@ from .compat import (
     RAISE,
 )
 from .exceptions import UnsupportedValueError
-from .validation import (handle_length, handle_one_of, handle_range,
-                         handle_regexp)
+from .validation import handle_length, handle_one_of, handle_range, handle_regexp
 
 __all__ = ("JSONSchema",)
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -18,7 +18,8 @@ from .compat import (
     RAISE,
 )
 from .exceptions import UnsupportedValueError
-from .validation import handle_length, handle_one_of, handle_range
+from .validation import (handle_length, handle_one_of, handle_range,
+                         handle_regexp)
 
 __all__ = ("JSONSchema",)
 
@@ -78,6 +79,7 @@ FIELD_VALIDATORS = {
     validate.Length: handle_length,
     validate.OneOf: handle_one_of,
     validate.Range: handle_range,
+    validate.Regexp: handle_regexp,
 }
 
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -200,9 +200,16 @@ class JSONSchema(Schema):
                 schema = self._from_python_type(obj, field, pytype)
         # Apply any and all validators that field may have
         for validator in field.validators:
-            for map_class, map_handler in FIELD_VALIDATORS.items():
-                if issubclass(validator.__class__, map_class):
-                    schema = map_handler(schema, field, validator, obj)
+            if validator.__class__ in FIELD_VALIDATORS:
+                schema = FIELD_VALIDATORS[validator.__class__](
+                    schema, field, validator, obj
+                )
+            else:
+                base_class = getattr(
+                    validator, "_jsonschema_base_validator_class", None
+                )
+                if base_class is not None and base_class in FIELD_VALIDATORS:
+                    schema = FIELD_VALIDATORS[base_class](schema, field, validator, obj)
         return schema
 
     def _from_nested_schema(self, obj, field):

--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -120,3 +120,35 @@ def handle_range(schema, field, validator, parent_schema):
         else:
             schema["exclusiveMaximum"] = validator.max
     return schema
+
+
+def handle_regexp(schema, field, validator, parent_schema):
+    """Adds validation logic for ``marshmallow.validate.Regexp``, setting the
+    values appropriately ``fields.String`` and it's subclasses.
+
+    Args:
+        schema (dict): The original JSON schema we generated. This is what we
+            want to post-process.
+        field (fields.Field): The field that generated the original schema and
+            who this post-processor belongs to.
+        validator (marshmallow.validate.Regexp): The validator attached to the
+            passed in field.
+        parent_schema (marshmallow.Schema): The Schema instance that the field
+            belongs to.
+
+    Returns:
+        dict: New JSON Schema that has been post processed and
+            altered.
+
+    Raises:
+        UnsupportedValueError: Raised if the `field` is not an instance of
+            `fields.String`.
+    """
+    if not isinstance(field, fields.String):
+        raise UnsupportedValueError(
+            "'Regexp' validator for non-string fields is not supported"
+        )
+
+    schema["pattern"] = validator.regex.pattern
+
+    return schema

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -464,6 +464,7 @@ def test_sorting_properties():
     class TestSchema(Schema):
         class Meta:
             ordered = True
+
         d = fields.Str()
         c = fields.Str()
         a = fields.Str()
@@ -474,7 +475,7 @@ def test_sorting_properties():
     dumped = JSONSchema().dump(schema)
 
     properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
-    assert properties_names == ['a', 'c', 'd']
+    assert properties_names == ["a", "c", "d"]
 
     # Should be saving ordering of fields
     schema = TestSchema()
@@ -482,6 +483,6 @@ def test_sorting_properties():
     dumped = JSONSchema(props_ordered=True).dump(schema)
 
     properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
-    assert properties_names == ['d', 'c', 'a']
+    assert properties_names == ["d", "c", "a"]
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -429,3 +429,32 @@ def test_required_excluded_when_empty():
     dumped = validate_and_dump(schema)
 
     assert "required" not in dumped["definitions"]["TestSchema"]
+
+
+def test_datetime_based():
+    class TestSchema(Schema):
+        f_date = fields.Date()
+        f_datetime = fields.DateTime()
+        f_time = fields.Time()
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["f_date"] == {
+        "format": "date",
+        "title": "f_date",
+        "type": "string",
+    }
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["f_datetime"] == {
+        "format": "date-time",
+        "title": "f_datetime",
+        "type": "string",
+    }
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["f_time"] == {
+        "format": "time",
+        "title": "f_time",
+        "type": "string",
+    }

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -2,6 +2,7 @@ import pytest
 from marshmallow import Schema, fields, validate
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
+from marshmallow_jsonschema.compat import dot_data_backwards_compatible
 from . import UserSchema, validate_and_dump
 
 
@@ -472,17 +473,22 @@ def test_sorting_properties():
     # Should be sorting of fields
     schema = TestSchema()
 
-    dumped = JSONSchema().dump(schema)
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema)
+    data = dot_data_backwards_compatible(dumped)
 
-    properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
+    sorted_keys = sorted(data["definitions"]["TestSchema"]["properties"].keys())
+    properties_names = [k for k in sorted_keys]
     assert properties_names == ["a", "c", "d"]
 
     # Should be saving ordering of fields
     schema = TestSchema()
 
-    dumped = JSONSchema(props_ordered=True).dump(schema)
+    json_schema = JSONSchema(props_ordered=True)
+    dumped = json_schema.dump(schema)
+    data = dot_data_backwards_compatible(dumped)
 
-    properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
+    keys = data["definitions"]["TestSchema"]["properties"].keys()
+    properties_names = [k for k in keys]
+
     assert properties_names == ["d", "c", "a"]
-
-

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -458,3 +458,30 @@ def test_datetime_based():
         "title": "f_time",
         "type": "string",
     }
+
+
+def test_sorting_properties():
+    class TestSchema(Schema):
+        class Meta:
+            ordered = True
+        d = fields.Str()
+        c = fields.Str()
+        a = fields.Str()
+
+    # Should be sorting of fields
+    schema = TestSchema()
+
+    dumped = JSONSchema().dump(schema)
+
+    properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
+    assert properties_names == ['a', 'c', 'd']
+
+    # Should be saving ordering of fields
+    schema = TestSchema()
+
+    dumped = JSONSchema(props_ordered=True).dump(schema)
+
+    properties_names = list(dumped["definitions"]["TestSchema"]["properties"].keys())
+    assert properties_names == ['d', 'c', 'a']
+
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -129,8 +129,10 @@ def test_range_non_number_error():
 
 
 def test_regexp():
-    ipv4_regex = r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}"\
-                 r"([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    ipv4_regex = (
+        r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}"
+        r"([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    )
 
     class TestSchema(Schema):
         ip_address = fields.String(validate=validate.Regexp(ipv4_regex))
@@ -142,7 +144,7 @@ def test_regexp():
     assert dumped["definitions"]["TestSchema"]["properties"]["ip_address"] == {
         "title": "ip_address",
         "type": "string",
-        "pattern": ipv4_regex
+        "pattern": ipv4_regex,
     }
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -126,3 +126,31 @@ def test_range_non_number_error():
 
     with pytest.raises(UnsupportedValueError):
         json_schema.dump(schema)
+
+
+def test_regexp():
+    ipv4_regex = r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}"\
+                 r"([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+
+    class TestSchema(Schema):
+        ip_address = fields.String(validate=validate.Regexp(ipv4_regex))
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["ip_address"] == {
+        "title": "ip_address",
+        "type": "string",
+        "pattern": ipv4_regex
+    }
+
+
+def test_regexp_error():
+    class TestSchema(Schema):
+        test_regexp = fields.Int(validate=validate.Regexp(r"\d+"))
+
+    schema = TestSchema()
+
+    with pytest.raises(UnsupportedValueError):
+        dumped = validate_and_dump(schema)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -156,3 +156,19 @@ def test_regexp_error():
 
     with pytest.raises(UnsupportedValueError):
         dumped = validate_and_dump(schema)
+
+
+def test_custom_validator():
+    class TestValidator(validate.Range):
+        _jsonschema_base_validator_class = validate.Range
+
+    class TestSchema(Schema):
+        test_field = fields.Int(validate=TestValidator(min=1, max=10))
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert props["test_field"]["minimum"] == 1
+    assert props["test_field"]["maximum"] == 10


### PR DESCRIPTION
Hi @fuhrysteve !

### What happened
I found one bug on dumping schemas with `Date` fields. In result of dump json schema field `Date` got wrong format `date-time`. It depend on order in tuple MARSHMALLOW_TO_PY_TYPES_PAIRS. I moved fields.DateTime after `fields.Time` and `fields.Date`.

### What I done
1.  Was move rule for **datetime.datetime** to bottom on after rules of **datetime.date** and **datetime.time**.
2. I added handling for marshmallow Regexp validator.
3. I added boolean named argument **props_ordered** on **JSONSchema** class constructor. This allows to enable field order preservation in properties.
4. Allows using custom validators (based on marshmallow supported validators). Using class attribute **_jsonschema_base_validator_class** for indicate the base validator.