### PR TITLE
bump dependency versions, drop python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     - os: linux
       python: "3.6"
     - os: linux
-      python: "3.5"
-    - os: linux
       python: "pypy3"
 before_install:
   - pip install -U pip

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 0.11.0 (unreleased)
-    - drop support for python 2 and marshmallow 2.
-      Python >= 3.5 and marshmallow >= 3 are now required!
+    - drop support for python 2 & 3.5, as well as marshmallow 2.
+      Python >= 3.6 and marshmallow >= 3 are now required!
 
 0.10.0 (2020-03-03)
     - added ReactJsonSchemaFormJSONSchema extension

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or mobile device).
 
 #### Installation
 
-Requires python>=3 and marshmallow>=3. (For python 2 & marshmallow 2 support, please use marshmallow-jsonschema<0.11)
+Requires python>=3.6 and marshmallow>=3. (For python 2 & marshmallow 2 support, please use marshmallow-jsonschema<0.11)
 
 ```
 pip install marshmallow-jsonschema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
-coverage>=4.5.3
-jsonschema>=3.0.1
-pytest>=4.6.3
+coverage>=5.2.1
+jsonschema>=3.2
+pytest>=6.0.1
 pytest-cov
 
-pre-commit~=1.17
+pre-commit~=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-marshmallow>=2.9.0
+marshmallow>=3

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=lint,py{35,36,37,38,py3}
+envlist=lint,py{36,37,38,py3}
 
 [testenv]
 deps=-r requirements-test.txt


### PR DESCRIPTION
Python 3.5 is EOL September 13, 2020. pre-commit dropped support for it, and there appear to be [very few python 3.5](https://pypistats.org/packages/marshmallow-jsonschema) downloads. As such, I'm just going to get ahead of the curve and drop support for it now.

Python 3.5 should still work and I'll still accept patches for awhile!! We're just not officially supporting it anymore in the build.