### PR TITLE
Generate correct "type" for Integer fields

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -30,7 +30,7 @@ PY_TO_JSON_TYPES_MAP = {
     set: {"type": "array"},
     tuple: {"type": "array"},
     float: {"type": "number", "format": "float"},
-    int: {"type": "number", "format": "integer"},
+    int: {"type": "integer"},
     bool: {"type": "boolean"},
 }
 


### PR DESCRIPTION
Closes #117 

Using a `type` of `number` and a `format` of `integer` is not documented in the [JSON schema specification](
https://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=integer#integer) as a correct way to represent integers. Instead, a `type` of `integer` should be used as this ensure that validators will correctly validate inputs as an integer and not accept
`number` values.

This *is* a breaking change as there is potential for previous successful validations to fail if users are validating `number` (e.g. floats) values against integer fields.
