### PR TITLE
Add support for marshmallow_union and marshmallow_enum

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
       Python >= 3.6 and marshmallow >= 3 are now required!
       Python 3.5 should still work - no breaking changes yet,
       it just isn't a part of the build anymore.
+    - add optional support for marshmallow_enum and marshmallow_union.
 
 0.10.0 (2020-03-03)
     - added ReactJsonSchemaFormJSONSchema extension

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -138,7 +138,7 @@ class JSONSchema(Schema):
         self.nested = kwargs.pop("nested", False)
         self.props_ordered = kwargs.pop("props_ordered", False)
         setattr(self.opts, "ordered", self.props_ordered)
-        super(JSONSchema, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_properties(self, obj):
         """Fill out properties field."""
@@ -314,7 +314,7 @@ class JSONSchema(Schema):
     def dump(self, obj, **kwargs):
         """Take obj for later use: using class name to namespace definition."""
         self.obj = obj
-        return super(JSONSchema, self).dump(obj, **kwargs)
+        return super().dump(obj, **kwargs)
 
     @post_dump
     def wrap(self, data, **_):

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import uuid
+from enum import Enum
 from inspect import isclass
 
 from marshmallow import fields, missing, Schema, validate
@@ -8,6 +9,21 @@ from marshmallow.class_registry import get_class
 from marshmallow.decorators import post_dump
 
 from marshmallow import INCLUDE, EXCLUDE, RAISE
+
+try:
+    from marshmallow_union import Union
+
+    ALLOW_UNIONS = True
+except ImportError:
+    ALLOW_UNIONS = False
+
+try:
+    from marshmallow_enum import EnumField, LoadDumpOptions
+
+    ALLOW_ENUMS = True
+except ImportError:
+    ALLOW_ENUMS = False
+
 from .exceptions import UnsupportedValueError
 from .validation import handle_length, handle_one_of, handle_range, handle_regexp
 
@@ -32,6 +48,7 @@ PY_TO_JSON_TYPES_MAP = {
     float: {"type": "number", "format": "float"},
     int: {"type": "number", "format": "integer"},
     bool: {"type": "boolean"},
+    Enum: {"type": "string"},
 }
 
 # We use these pairs to get proper python type from marshmallow type.
@@ -64,6 +81,12 @@ MARSHMALLOW_TO_PY_TYPES_PAIRS = (
     # unknown marshmallow fields more cleanly.
     (fields.Nested, dict),
 )
+
+if ALLOW_ENUMS:
+    # We currently only support loading enum's from their names. So the possible
+    # values will always map to string in the JSONSchema
+    MARSHMALLOW_TO_PY_TYPES_PAIRS += ((EnumField, Enum),)
+
 
 FIELD_VALIDATORS = {
     validate.Length: handle_length,
@@ -144,7 +167,7 @@ class JSONSchema(Schema):
 
     def _from_python_type(self, obj, field, pytype):
         """Get schema definition from python type."""
-        json_schema = {"title": field.attribute or field.name}
+        json_schema = {"title": field.attribute or field.name or ""}
 
         for key, val in PY_TO_JSON_TYPES_MAP[pytype].items():
             json_schema[key] = val
@@ -154,6 +177,9 @@ class JSONSchema(Schema):
 
         if field.default is not missing:
             json_schema["default"] = field.default
+
+        if ALLOW_ENUMS and isinstance(field, EnumField):
+            json_schema["enum"] = self._get_enum_values(field)
 
         if field.allow_none:
             previous_type = json_schema["type"]
@@ -172,6 +198,29 @@ class JSONSchema(Schema):
             json_schema["items"] = self._get_schema_for_field(obj, field.inner)
         return json_schema
 
+    def _get_enum_values(self, field):
+        assert ALLOW_ENUMS and isinstance(field, EnumField)
+
+        if field.load_by == LoadDumpOptions.value:
+            # Python allows enum values to be almost anything, so it's easier to just load from the
+            # names of the enum's which will have to be strings.
+            raise NotImplementedError(
+                "Currently do not support JSON schema for enums loaded by value"
+            )
+
+        return [value.name for value in field.enum]
+
+    def _from_union_schema(self, obj, field):
+        """Get a union type schema. Uses anyOf to allow the value to be any of the provided sub fields"""
+        assert ALLOW_UNIONS and isinstance(field, Union)
+
+        return {
+            "anyOf": [
+                self._get_schema_for_field(obj, sub_field)
+                for sub_field in field._candidate_fields
+            ]
+        }
+
     def _get_python_type(self, field):
         """Get python type based on field subclass"""
         for map_class, pytype in MARSHMALLOW_TO_PY_TYPES_PAIRS:
@@ -187,11 +236,13 @@ class JSONSchema(Schema):
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
         else:
-            pytype = self._get_python_type(field)
             if isinstance(field, fields.Nested):
                 # Special treatment for nested fields.
                 schema = self._from_nested_schema(obj, field)
+            elif ALLOW_UNIONS and isinstance(field, Union):
+                schema = self._from_union_schema(obj, field)
             else:
+                pytype = self._get_python_type(field)
                 schema = self._from_python_type(obj, field, pytype)
         # Apply any and all validators that field may have
         for validator in field.validators:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,8 @@ coverage>=5.2.1
 jsonschema>=3.2
 pytest>=6.0.1
 pytest-cov
+# Optional installs for the wheel, but always required for tests
+marshmallow-enum
+marshmallow-union
 
 pre-commit~=2.6

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ REQUIREMENTS_TESTS = open(
 REQUIREMENTS_TOX_FILE = "requirements-tox.txt"
 REQUIREMENTS_TOX = open(os.path.join(PROJECT_DIR, REQUIREMENTS_TOX_FILE)).readlines()
 
+EXTRAS_REQUIRE = {
+    "enum": ["marshmallow-enum"],
+    "union": ["marshmallow-union"],
+}
+
 
 setup(
     name="marshmallow-jsonschema",
@@ -45,6 +50,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     tests_require=REQUIREMENTS_TESTS + REQUIREMENTS_TOX,
+    extras_require=EXTRAS_REQUIRE,
     license=read("LICENSE"),
     zip_safe=False,
     keywords=(

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -536,6 +536,24 @@ def test_enum_based():
     assert received_enum_values == ["value_1", "value_2", "value_3"]
 
 
+def test_enum_based_load_dump_value():
+    class TestEnum(Enum):
+        value_1 = 0
+        value_2 = 1
+        value_3 = 2
+
+    class TestSchema(Schema):
+        enum_prop = EnumField(TestEnum, by_value=True)
+
+    # Should be sorting of fields
+    schema = TestSchema()
+
+    json_schema = JSONSchema()
+
+    with pytest.raises(NotImplementedError):
+        validate_and_dump(json_schema.dump(schema))
+
+
 def test_union_based():
     class TestNestedSchema(Schema):
         field_1 = fields.String()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,5 +1,9 @@
+from enum import Enum
+
 import pytest
 from marshmallow import Schema, fields, validate
+from marshmallow_enum import EnumField
+from marshmallow_union import Union
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
 from . import UserSchema, validate_and_dump
@@ -506,3 +510,83 @@ def test_sorting_properties():
     properties_names = [k for k in keys]
 
     assert properties_names == ["d", "c", "a"]
+
+
+def test_enum_based():
+    class TestEnum(Enum):
+        value_1 = 0
+        value_2 = 1
+        value_3 = 2
+
+    class TestSchema(Schema):
+        enum_prop = EnumField(TestEnum)
+
+    # Should be sorting of fields
+    schema = TestSchema()
+
+    json_schema = JSONSchema()
+    data = json_schema.dump(schema)
+
+    assert (
+        data["definitions"]["TestSchema"]["properties"]["enum_prop"]["type"] == "string"
+    )
+    received_enum_values = sorted(
+        data["definitions"]["TestSchema"]["properties"]["enum_prop"]["enum"]
+    )
+    assert received_enum_values == ["value_1", "value_2", "value_3"]
+
+
+def test_union_based():
+    class TestNestedSchema(Schema):
+        field_1 = fields.String()
+        field_2 = fields.Integer()
+
+    class TestSchema(Schema):
+        union_prop = Union(
+            [fields.String(), fields.Integer(), fields.Nested(TestNestedSchema)]
+        )
+
+    # Should be sorting of fields
+    schema = TestSchema()
+
+    json_schema = JSONSchema()
+    data = json_schema.dump(schema)
+
+    # Expect only the `anyOf` key
+    assert "anyOf" in data["definitions"]["TestSchema"]["properties"]["union_prop"]
+    assert len(data["definitions"]["TestSchema"]["properties"]["union_prop"]) == 1
+
+    string_schema = {"type": "string", "title": ""}
+    integer_schema = {"type": "string", "title": ""}
+    referenced_nested_schema = {
+        "type": "object",
+        "$ref": "#/definitions/TestNestedSchema",
+    }
+    actual_nested_schema = {
+        "type": "object",
+        "properties": {
+            "field_1": {"type": "string", "title": "field_1"},
+            "field_2": {"type": "number", "title": "field_2", "format": "integer"},
+        },
+        "additionalProperties": False,
+    }
+
+    assert (
+        string_schema
+        in data["definitions"]["TestSchema"]["properties"]["union_prop"]["anyOf"]
+    )
+    assert (
+        integer_schema
+        in data["definitions"]["TestSchema"]["properties"]["union_prop"]["anyOf"]
+    )
+    assert (
+        referenced_nested_schema
+        in data["definitions"]["TestSchema"]["properties"]["union_prop"]["anyOf"]
+    )
+
+    assert data["definitions"]["TestNestedSchema"] == actual_nested_schema
+
+    # Expect three possible schemas for the union type
+    assert (
+        len(data["definitions"]["TestSchema"]["properties"]["union_prop"]["anyOf"]) == 3
+    )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,26 @@
+import importlib
+import marshmallow_jsonschema
+
+
+def test_import_marshmallow_union(monkeypatch):
+    monkeypatch.delattr("marshmallow_union.Union")
+
+    base = importlib.reload(marshmallow_jsonschema.base)
+
+    assert not base.ALLOW_UNIONS
+
+    monkeypatch.undo()
+
+    importlib.reload(marshmallow_jsonschema.base)
+
+
+def test_import_marshmallow_enum(monkeypatch):
+    monkeypatch.delattr("marshmallow_enum.EnumField")
+
+    base = importlib.reload(marshmallow_jsonschema.base)
+
+    assert not base.ALLOW_ENUMS
+
+    monkeypatch.undo()
+
+    importlib.reload(marshmallow_jsonschema.base)


### PR DESCRIPTION
Add optional support for marshmallow_union and marshmallow_enum.

This will provide useful integration with the [marshmallow_dataclass](https://github.com/lovasoa/marshmallow_dataclass) package which also utilises these packages and makes setting up marshmallow schemas easy. 