### PR TITLE
Nested allow_none=True implementation

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -241,7 +241,7 @@ class JSONSchema(Schema):
             self._nested_schema_classes.update(wrapped_nested._nested_schema_classes)
 
         # and the schema is just a reference to the def
-        schema = {"type": "object", "$ref": "#/definitions/{}".format(name)}
+        schema = {"$ref": "#/definitions/{}".format(name)}
 
         # NOTE: doubled up to maintain backwards compatibility
         metadata = field.metadata.get("metadata", {})

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -252,6 +252,14 @@ class JSONSchema(Schema):
                 continue
             schema[md_key] = md_val
 
+        if field.allow_none:
+            schema = {
+                "anyOf": [
+                    schema, 
+                    {"type": "null"}
+                ]
+            }
+
         if field.many:
             schema = {
                 "type": "array" if field.required else ["array", "null"],

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -102,7 +102,6 @@ def test_nested_string_to_cls():
 
     nested_def = dumped["definitions"]["TestNamedNestedSchema"]
     nested_dmp = dumped["definitions"]["TestSchema"]["properties"]["nested"]
-    assert nested_dmp["type"] == "object"
     assert nested_def["properties"]["foo"]["format"] == "integer"
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -415,6 +415,27 @@ def test_allow_none():
     }
 
 
+def test_allow_none_on_nested():
+    """A Nested field with allow_none set to True should result in anyOf"""
+    class ChildSchema(Schema):
+        id = fields.Integer(required=True)
+
+    class TestSchema(Schema):
+        id = fields.Integer(required=True)
+        nested_fld = fields.Nested(ChildSchema, allow_none=True)
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["nested_fld"] == {
+        "anyOf": [
+            {'$ref': '#/definitions/ChildSchema'},
+            {"type": "null"}
+        ]
+    }
+
+
 def test_dumps_iterable_enums():
     mapping = {"a": 0, "b": 1, "c": 2}
 


### PR DESCRIPTION
Fixes #121 and removes `"type": "object"` from referenced schemas