### PR TITLE
Added fields.IP marshmallow field type to python types mapping

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -85,6 +85,7 @@ MARSHMALLOW_TO_PY_TYPES_PAIRS = [
     (fields.Url, str),
     (fields.List, list),
     (fields.Number, decimal.Decimal),
+    (fields.IP, str),
     # This one is here just for completeness sake and to check for
     # unknown marshmallow fields more cleanly.
     (fields.Nested, dict),


### PR DESCRIPTION
Added support for type IP of marshmallow fields, So it could be inside a marshmallow schema that will be translated to json schema using this library.