### PR TITLE
Use data_key when available for property names

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -161,7 +161,9 @@ class JSONSchema(Schema):
 
         for field_name, field in fields_items_sequence:
             schema = self._get_schema_for_field(obj, field)
-            properties[field.metadata.get("name") or field.name] = schema
+            properties[
+                field.metadata.get("name") or field.data_key or field.name
+            ] = schema
 
         return properties
 
@@ -171,7 +173,7 @@ class JSONSchema(Schema):
 
         for field_name, field in sorted(obj.fields.items()):
             if field.required:
-                required.append(field.name)
+                required.append(field.data_key or field.name)
 
         return required or missing
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -505,6 +505,21 @@ def test_required_excluded_when_empty():
     assert "required" not in dumped["definitions"]["TestSchema"]
 
 
+def test_required_uses_data_key():
+    class TestSchema(Schema):
+        optional_value = fields.String(data_key="opt", required=True)
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    test_schema_definition = dumped["definitions"]["TestSchema"]
+    assert "opt" in test_schema_definition["properties"]
+    assert "optional_value" == test_schema_definition["properties"]["opt"]["title"]
+    assert "required" in test_schema_definition
+    assert "opt" in test_schema_definition["required"]
+
+
 def test_datetime_based():
     class TestSchema(Schema):
         f_date = fields.Date()


### PR DESCRIPTION
A field has an optional `data_key` which can hold an alternative
output key name. When dumping a schema, the `data_key` should be
used instead of the name.