### PR TITLE
The UUID field inherits from the String field

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -67,12 +67,12 @@ PY_TO_JSON_TYPES_MAP = {
 MARSHMALLOW_TO_PY_TYPES_PAIRS = [
     # This part of a mapping is carefully selected from marshmallow source code,
     # see marshmallow.BaseSchema.TYPE_MAPPING.
+    (fields.UUID, uuid.UUID),
     (fields.String, str),
     (fields.Float, float),
     (fields.Raw, str),
     (fields.Boolean, bool),
     (fields.Integer, int),
-    (fields.UUID, uuid.UUID),
     (fields.Time, datetime.time),
     (fields.Date, datetime.date),
     (fields.TimeDelta, datetime.timedelta),

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -30,6 +30,16 @@ def test_default():
     assert props["id"]["default"] == "no-id"
 
 
+def test_uuid():
+    schema = UserSchema()
+
+    dumped = validate_and_dump(schema)
+
+    props = dumped["definitions"]["UserSchema"]["properties"]
+    assert props["uid"]["type"] == "string"
+    assert props["uid"]["format"] == "uuid"
+
+
 def test_metadata():
     """Metadata should be available in the field definition."""
 


### PR DESCRIPTION
So we need to check if a field inherits UUID before checking for String.

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>