### PR TITLE
fix: Change readonly to readOnly

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -185,7 +185,7 @@ class JSONSchema(Schema):
             json_schema[key] = val
 
         if field.dump_only:
-            json_schema["readonly"] = True
+            json_schema["readOnly"] = True
 
         if field.default is not missing:
             json_schema["default"] = field.default

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -444,7 +444,7 @@ def test_readonly():
     assert dumped["definitions"]["TestSchema"]["properties"]["readonly_fld"] == {
         "title": "readonly_fld",
         "type": "string",
-        "readonly": True,
+        "readOnly": True,
     }
 
 


### PR DESCRIPTION
Change the `readonly` attribute to `readOnly` as per the Json Schema [specification](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.4).