### PR TITLE
Fixes to field default

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -324,6 +324,9 @@ class JSONSchema(Schema):
                 continue
             schema[md_key] = md_val
 
+        if field.default is not missing and not callable(field.default):
+            schema["default"] = nested_instance.dump(field.default)
+
         if field.many:
             schema = {
                 "type": "array" if field.required else ["array", "null"],

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -187,7 +187,7 @@ class JSONSchema(Schema):
         if field.dump_only:
             json_schema["readOnly"] = True
 
-        if field.default is not missing:
+        if field.default is not missing and not callable(field.default):
             json_schema["default"] = field.default
 
         if ALLOW_ENUMS and isinstance(field, EnumField):

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -307,6 +307,25 @@ def test_respect_dotted_exclude_for_nested_schema():
     assert "recursive" not in inner_props
 
 
+def test_respect_default_for_nested_schema():
+    class TestNestedSchema(Schema):
+        myfield = fields.String()
+        yourfield = fields.Integer(required=True)
+
+    nested_default = {"myfield": "myval", "yourfield": 1}
+
+    class TestSchema(Schema):
+        nested = fields.Nested(
+            TestNestedSchema, default=nested_default,
+        )
+        yourfield_nested = fields.Integer(required=True)
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+    default = dumped["definitions"]["TestSchema"]["properties"]["nested"]["default"]
+    assert default == nested_default
+
+
 def test_nested_instance():
     """Should also work with nested schema instances"""
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,3 +1,4 @@
+import uuid
 from enum import Enum
 
 import pytest
@@ -28,6 +29,18 @@ def test_default():
 
     props = dumped["definitions"]["UserSchema"]["properties"]
     assert props["id"]["default"] == "no-id"
+
+
+def test_default_callable_not_serialized():
+    class TestSchema(Schema):
+        uid = fields.UUID(default=uuid.uuid4)
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert "default" not in props["uid"]
 
 
 def test_uuid():
@@ -316,7 +329,8 @@ def test_respect_default_for_nested_schema():
 
     class TestSchema(Schema):
         nested = fields.Nested(
-            TestNestedSchema, default=nested_default,
+            TestNestedSchema,
+            default=nested_default,
         )
         yourfield_nested = fields.Integer(required=True)
 


### PR DESCRIPTION
This fixes two issues:
1. The default value for nested fields wasn't serialized.
2. The default value for other fields may be a callable and in that case it shouldn't be emitted into the schema.

Fixes #143