### PR TITLE
Support JSON schema for enums always loaded by name

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -221,13 +221,6 @@ class JSONSchema(Schema):
     def _get_enum_values(self, field) -> typing.List[str]:
         assert ALLOW_ENUMS and isinstance(field, EnumField)
 
-        if field.load_by == LoadDumpOptions.value:
-            # Python allows enum values to be almost anything, so it's easier to just load from the
-            # names of the enum's which will have to be strings.
-            raise NotImplementedError(
-                "Currently do not support JSON schema for enums loaded by value"
-            )
-
         return [value.name for value in field.enum]
 
     def _from_union_schema(

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -658,10 +658,15 @@ def test_enum_based_load_dump_value():
     # Should be sorting of fields
     schema = TestSchema()
 
-    json_schema = JSONSchema()
+    data = validate_and_dump(schema)
 
-    with pytest.raises(NotImplementedError):
-        validate_and_dump(json_schema.dump(schema))
+    assert (
+            data["definitions"]["TestSchema"]["properties"]["enum_prop"]["type"] == "string"
+    )
+    received_enum_values = sorted(
+        data["definitions"]["TestSchema"]["properties"]["enum_prop"]["enum"]
+    )
+    assert received_enum_values == ["value_1", "value_2", "value_3"]
 
 
 def test_union_based():


### PR DESCRIPTION
`marshmallow_enum` already supports load by value and load by name.
https://github.com/justanr/marshmallow_enum

The goal I want is to dump my JsonScheam which has enum in it.
```
@dataclass_json
@dataclass
class Datum(object):
    x: Color

schema = Datum.schema()
JSONSchema().dump(schema)
```

Error message before change
```
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow/fields.py", line 338, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow/fields.py", line 1864, in _serialize
    return self._serialize_method(obj)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 163, in get_properties
    schema = self._get_schema_for_field(obj, field)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 267, in _get_schema_for_field
    schema = self._from_python_type(obj, field, pytype)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 194, in _from_python_type
    json_schema["enum"] = self._get_enum_values(field)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 226, in _get_enum_values
    raise NotImplementedError(
NotImplementedError: Currently do not support JSON schema for enums loaded by value
```
