### PR TITLE
give more context to custom schemas

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -254,7 +254,7 @@ class JSONSchema(Schema):
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
         if hasattr(field, "_jsonschema_type_mapping"):
-            schema = field._jsonschema_type_mapping()
+            schema = field._jsonschema_type_mapping(self, obj)
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
         else:

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import uuid
 from enum import Enum
-from inspect import isclass
+from inspect import isclass, signature
 import typing
 
 from marshmallow import fields, missing, Schema, validate
@@ -254,7 +254,15 @@ class JSONSchema(Schema):
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
         if hasattr(field, "_jsonschema_type_mapping"):
-            schema = field._jsonschema_type_mapping(self, obj)
+            sig = signature(field._jsonschema_type_mapping)
+            num_args = len(sig.parameters)
+            if num_args == 2:
+                # pass down extra context to nested field of
+                # this schema and obj context if the implementer
+                # explicitly expects it
+                schema = field._jsonschema_type_mapping(self, obj)
+            else:
+                schema = field._jsonschema_type_mapping()
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
         else:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -454,7 +454,7 @@ def test_unknown_typed_field_throws_valueerror():
 
 def test_unknown_typed_field():
     class Colour(fields.Field):
-        def _jsonschema_type_mapping(self, json_schema, obj):
+        def _jsonschema_type_mapping(self):
             return {"type": "string"}
 
         def _serialize(self, value, attr, obj):

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -454,7 +454,7 @@ def test_unknown_typed_field_throws_valueerror():
 
 def test_unknown_typed_field():
     class Colour(fields.Field):
-        def _jsonschema_type_mapping(self):
+        def _jsonschema_type_mapping(self, json_schema, obj):
             return {"type": "string"}
 
         def _serialize(self, value, attr, obj):
@@ -744,3 +744,26 @@ def test_union_based():
     assert (
         len(data["definitions"]["TestSchema"]["properties"]["union_prop"]["anyOf"]) == 3
     )
+
+def test_recursive_custom_field():
+    class NoOpWrapper(fields.Field):
+        def __init__(self, field):
+            self.field = field
+            super().__init__()
+
+        def _jsonschema_type_mapping(self, json_schema, obj):
+            field_schema = json_schema._get_schema_for_field(obj, self.field)
+            return field_schema
+
+    class ContrivedSchema(Schema):
+        recursive = NoOpWrapper(
+            fields.Nested("ContrivedSchema"),
+        )
+
+    schema = ContrivedSchema()
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["ContrivedSchema"]["properties"]["recursive"] == {
+        "type": "object",
+        "$ref": "#/definitions/ContrivedSchema"
+    }


### PR DESCRIPTION
Kind of a corner case, I have a schema with a custom field that holds a recursive instance of that same schema, and I got blocked on not having access to `obj` in my custom `_jsonschema_type_mapping` call