### PR TITLE
Update black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
     language_version: python3


### PR DESCRIPTION
Update black version to fix

```
ImportError: cannot import name '_unicodefun' from 'click'
```

I didn't bump to the latest release as this may require code reformatting