### PR TITLE
Remove `type` for `fields.Raw`

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -223,6 +223,8 @@ class JSONSchema(Schema):
                 if field.value_field
                 else {}
             )
+        if isinstance(field, fields.Raw):
+            json_schema.pop("type", None)
         return json_schema
 
     def _get_enum_values(self, field) -> typing.List[str]:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -211,6 +211,17 @@ def test_dict():
     assert item_schema == {}
 
 
+def test_raw():
+    class RawSchema(Schema):
+        foo = fields.Raw()
+    
+    schema = RawSchema()
+    dumped = validate_and_dump(schema)
+
+    nested_json = dumped["definitions"]["RawSchema"]["properties"]["foo"]
+    assert "type" not in nested_json
+
+
 def test_dict_with_value_field():
     class DictSchema(Schema):
         foo = fields.Dict(keys=fields.String, values=fields.Integer)


### PR DESCRIPTION
marshmallow field `Raw` means the value can be any type, but there is no equivalent type for json schema. Current behavior is to generate a type `string` which is not appropriate imo.

We can remove `type` attribute so the json schema parser won't raise error for property generated from `fields.Raw`.