### PR TITLE
Allow callable defaults and verify serializability

### DIFF
--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -42,6 +42,17 @@ def test_default_callable_not_serialized():
     props = dumped["definitions"]["TestSchema"]["properties"]
     assert "default" not in props["uid"]
 
+def test_default_callable_serialized():
+    class TestSchema(Schema):
+        uid = fields.UUID(default=lambda: str(uuid.uuid4()))
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert "default" in props["uid"]
+
 
 def test_uuid():
     schema = UserSchema()


### PR DESCRIPTION
checking if the default value is callable is not sufficient, as one can provide a default value that is not callable nor serializable, `uuid.uuid4()`  for example.


this change enables providing callable as a default value and also verifies that the value is serializable