### PR TITLE
Break dependency from setuptools

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+0.13.1-rc2 (2025-12-05)
+    - Break dependencu from setuptools
 0.13.0 (2021-10-21)
     - Fixes to field default #151
       - The default value for nested fields wasn't serialized.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.13.1-rc2 (2025-12-05)
+0.13.1 (2025-12-05)
     - Break dependencu from setuptools
 0.13.0 (2021-10-21)
     - Fixes to field default #151

--- a/marshmallow_jsonschema/__init__.py
+++ b/marshmallow_jsonschema/__init__.py
@@ -1,6 +1,6 @@
-from pkg_resources import get_distribution
+from importlib import metadata
 
-__version__ = get_distribution("marshmallow-jsonschema").version
+__version__ = metadata.version("marshmallow-jsonschema")
 __license__ = "MIT"
 
 from .base import JSONSchema

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="marshmallow-jsonschema",
-    version="0.13.1-rc2",
+    version="0.13.1",
     description="JSON Schema Draft v7 (http://json-schema.org/)"
     " formatting with marshmallow",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="marshmallow-jsonschema",
-    version="0.13.0",
+    version="0.13.1-rc2",
     description="JSON Schema Draft v7 (http://json-schema.org/)"
     " formatting with marshmallow",
     long_description=long_description,


### PR DESCRIPTION
In modern python setups, dependencies to setuptools are deprecated. Here is the contribution to break it.

It fixes issues like these

```python
File "/venv/lib/python3.13/site-packages/marshmallow_jsonschema/__init__.py", line 1, in <module>
    from pkg_resources import get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```