### PR TITLE
Modernize CI: drop EOL Python, add 3.12/3.13, bump actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
         #
         # Please bump to the latest unreleased candidate
         # when you come across this and have a moment to spare!
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -3,24 +3,29 @@ name: Lint
 on:
   push:
     paths:
-      - '*.py'
+      - '**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/mypy.yml'
+  pull_request:
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/mypy.yml'
 
 jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          architecture: x64
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install mypy
-        run: pip install mypy
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+          pip install -e .
       - name: Run mypy
-        uses: sasanquaneuf/mypy-github-action@releases/v1
-        with:
-          checkName: 'mypy'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mypy marshmallow_jsonschema

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11.2
+          python-version: '3.12'
           architecture: x64
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install mypy
         run: pip install mypy
       - name: Run mypy

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -166,9 +166,9 @@ class JSONSchema(Schema):
 
         for field_name, field in fields_items_sequence:
             schema = self._get_schema_for_field(obj, field)
-            properties[
-                field.metadata.get("name") or field.data_key or field.name
-            ] = schema
+            properties[field.metadata.get("name") or field.data_key or field.name] = (
+                schema
+            )
 
         return properties
 

--- a/marshmallow_jsonschema/extensions/__init__.py
+++ b/marshmallow_jsonschema/extensions/__init__.py
@@ -1,4 +1,3 @@
 from .react_jsonschema_form import ReactJsonSchemaFormJSONSchema
 
-
 __all__ = ("ReactJsonSchemaFormJSONSchema",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [tool.black]
 target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+
+[[tool.mypy.overrides]]
+module = ["marshmallow_enum", "marshmallow_union"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-target-version = ['py39', 'py310']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-marshmallow>=3.11
+marshmallow>=3.11,<4

--- a/setup.py
+++ b/setup.py
@@ -54,17 +54,17 @@ setup(
         "marshmallow-jsonschema marshmallow schema serialization "
         "jsonschema validation"
     ),
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 
 from setuptools import setup, find_packages
 
-
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{37,38,39,310,311,py3}
+envlist=py{39,310,311,312,313,py3}
 
 [testenv]
 deps=-r requirements-test.txt


### PR DESCRIPTION
## Summary
- CI matrix now targets Python 3.9–3.13. Drops 3.7 and 3.8 (both EOL).
- Bumps \`actions/setup-python\` → v5 and \`actions/checkout\` → v4 across all workflows.
- Updates \`setup.py\` classifiers and \`python_requires\`, \`pyproject.toml\` black target-versions, and \`tox.ini\` envlist.
- Applies black formatting to two files that had drifted since the black workflow always runs the latest stable.

This extracts the useful parts of #183 on top of #185 (which already landed the \`pkg_resources\` → \`importlib.metadata\` fix). The rest of #183 was conflicting cosmetic noise.

## Test plan
- [x] Local pytest on Python 3.10 with \`marshmallow<4\` → 64 passed
- [x] \`black --check\` clean
- [ ] Confirm CI matrix passes on all matrix versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)