### PR TITLE
Support marshmallow.fields.Enum (native Enum)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+unreleased
+    - Add support for `marshmallow.fields.Enum` (native Enum field added in
+      marshmallow 3.18). Existing `marshmallow_enum.EnumField` support is
+      preserved. #169, #170
+    - Internal: renamed `ALLOW_ENUMS` to `ALLOW_MARSHMALLOW_ENUM` for the
+      third-party package and added `ALLOW_NATIVE_ENUM` for the in-tree
+      field. `ALLOW_ENUMS` is retained as a backward-compatible alias
+      (True when either is active).
+
 0.13.0 (2021-10-21)
     - Fixes to field default #151
       - The default value for nested fields wasn't serialized.

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -22,9 +22,20 @@ except ImportError:
 try:
     from marshmallow_enum import EnumField, LoadDumpOptions
 
-    ALLOW_ENUMS = True
+    ALLOW_MARSHMALLOW_ENUM = True
 except ImportError:
-    ALLOW_ENUMS = False
+    ALLOW_MARSHMALLOW_ENUM = False
+
+try:
+    from marshmallow.fields import Enum as NativeEnumField
+
+    ALLOW_NATIVE_ENUM = True
+except ImportError:
+    ALLOW_NATIVE_ENUM = False
+
+# Backward-compatible alias. External code has historically imported
+# `ALLOW_ENUMS` to detect whether *any* enum support is active.
+ALLOW_ENUMS = ALLOW_MARSHMALLOW_ENUM or ALLOW_NATIVE_ENUM
 
 from .exceptions import UnsupportedValueError
 from .validation import (
@@ -92,10 +103,12 @@ MARSHMALLOW_TO_PY_TYPES_PAIRS = [
     (fields.Nested, dict),
 ]
 
-if ALLOW_ENUMS:
+if ALLOW_MARSHMALLOW_ENUM:
     # We currently only support loading enum's from their names. So the possible
     # values will always map to string in the JSONSchema
     MARSHMALLOW_TO_PY_TYPES_PAIRS.append((EnumField, Enum))
+if ALLOW_NATIVE_ENUM:
+    MARSHMALLOW_TO_PY_TYPES_PAIRS.append((NativeEnumField, Enum))
 
 
 FIELD_VALIDATORS = {
@@ -198,7 +211,9 @@ class JSONSchema(Schema):
         if field.default is not missing and not callable(field.default):
             json_schema["default"] = field.default
 
-        if ALLOW_ENUMS and isinstance(field, EnumField):
+        if ALLOW_NATIVE_ENUM and isinstance(field, NativeEnumField):
+            json_schema["enum"] = self._get_native_enum_values(field)
+        elif ALLOW_MARSHMALLOW_ENUM and isinstance(field, EnumField):
             json_schema["enum"] = self._get_enum_values(field)
 
         if field.allow_none:
@@ -226,9 +241,21 @@ class JSONSchema(Schema):
         return json_schema
 
     def _get_enum_values(self, field) -> typing.List[str]:
-        assert ALLOW_ENUMS and isinstance(field, EnumField)
+        assert ALLOW_MARSHMALLOW_ENUM and isinstance(field, EnumField)
 
         if field.load_by == LoadDumpOptions.value:
+            # Python allows enum values to be almost anything, so it's easier to just load from the
+            # names of the enum's which will have to be strings.
+            raise NotImplementedError(
+                "Currently do not support JSON schema for enums loaded by value"
+            )
+
+        return [value.name for value in field.enum]
+
+    def _get_native_enum_values(self, field) -> typing.List[str]:
+        assert ALLOW_NATIVE_ENUM and isinstance(field, NativeEnumField)
+
+        if field.by_value:
             # Python allows enum values to be almost anything, so it's easier to just load from the
             # names of the enum's which will have to be strings.
             raise NotImplementedError(

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,7 +7,11 @@ from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
+from marshmallow_jsonschema.base import ALLOW_NATIVE_ENUM
 from . import UserSchema, validate_and_dump
+
+if ALLOW_NATIVE_ENUM:
+    from marshmallow.fields import Enum as NativeEnumField
 
 
 def test_dump_schema():
@@ -684,6 +688,51 @@ def test_enum_based_load_dump_value():
     # Should be sorting of fields
     schema = TestSchema()
 
+    json_schema = JSONSchema()
+
+    with pytest.raises(NotImplementedError):
+        validate_and_dump(json_schema.dump(schema))
+
+
+@pytest.mark.skipif(
+    not ALLOW_NATIVE_ENUM, reason="requires marshmallow>=3.18 for native Enum field"
+)
+def test_native_enum_based():
+    class TestEnum(Enum):
+        value_1 = 0
+        value_2 = 1
+        value_3 = 2
+
+    class TestSchema(Schema):
+        enum_prop = NativeEnumField(TestEnum)
+
+    schema = TestSchema()
+
+    json_schema = JSONSchema()
+    data = json_schema.dump(schema)
+
+    assert (
+        data["definitions"]["TestSchema"]["properties"]["enum_prop"]["type"] == "string"
+    )
+    received_enum_values = sorted(
+        data["definitions"]["TestSchema"]["properties"]["enum_prop"]["enum"]
+    )
+    assert received_enum_values == ["value_1", "value_2", "value_3"]
+
+
+@pytest.mark.skipif(
+    not ALLOW_NATIVE_ENUM, reason="requires marshmallow>=3.18 for native Enum field"
+)
+def test_native_enum_based_by_value():
+    class TestEnum(Enum):
+        value_1 = 0
+        value_2 = 1
+        value_3 = 2
+
+    class TestSchema(Schema):
+        enum_prop = NativeEnumField(TestEnum, by_value=True)
+
+    schema = TestSchema()
     json_schema = JSONSchema()
 
     with pytest.raises(NotImplementedError):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -19,7 +19,7 @@ def test_import_marshmallow_enum(monkeypatch):
 
     base = importlib.reload(marshmallow_jsonschema.base)
 
-    assert not base.ALLOW_ENUMS
+    assert not base.ALLOW_MARSHMALLOW_ENUM
 
     monkeypatch.undo()
 


### PR DESCRIPTION
## Summary
- Adds support for \`marshmallow.fields.Enum\` (introduced in marshmallow 3.18, Sept 2022). Picks up the intent of #170 (credit: @hf-kklein) and cleans it up for landing on top of current master.
- Existing \`marshmallow_enum.EnumField\` support is preserved; when both are present, native Enum is preferred.
- Detects native Enum via a simple \`try: from marshmallow.fields import Enum\` rather than a \`packaging\`-based version comparison.
- Internal rename: \`ALLOW_ENUMS\` → \`ALLOW_MARSHMALLOW_ENUM\` (third-party) and \`ALLOW_NATIVE_ENUM\` (in-tree). \`ALLOW_ENUMS\` retained as a backward-compat alias (True when either is active).

Closes #169. Supersedes #170.

## Test plan
- [x] \`pytest\` — 66 passed (64 prior + 2 new native-Enum tests)
- [x] \`mypy marshmallow_jsonschema\` — clean
- [x] \`black --check .\` — clean
- [ ] CI matrix 3.9–3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)