### PR TITLE
Replace deprecated field.default with field.dump_default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ unreleased
       third-party package and added `ALLOW_NATIVE_ENUM` for the in-tree
       field. `ALLOW_ENUMS` is retained as a backward-compatible alias
       (True when either is active).
+    - Replace deprecated `field.default` reads with `field.dump_default` to
+      silence `RemovedInMarshmallow4Warning`. Minimum supported marshmallow
+      is now 3.13. #158, #167
 
 0.13.0 (2021-10-21)
     - Fixes to field default #151

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -208,8 +208,8 @@ class JSONSchema(Schema):
         if field.dump_only:
             json_schema["readOnly"] = True
 
-        if field.default is not missing and not callable(field.default):
-            json_schema["default"] = field.default
+        if field.dump_default is not missing and not callable(field.dump_default):
+            json_schema["default"] = field.dump_default
 
         if ALLOW_NATIVE_ENUM and isinstance(field, NativeEnumField):
             json_schema["enum"] = self._get_native_enum_values(field)
@@ -364,8 +364,8 @@ class JSONSchema(Schema):
                 continue
             schema[md_key] = md_val
 
-        if field.default is not missing and not callable(field.default):
-            schema["default"] = nested_instance.dump(field.default)
+        if field.dump_default is not missing and not callable(field.dump_default):
+            schema["default"] = nested_instance.dump(field.dump_default)
 
         if field.many:
             schema = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-marshmallow>=3.11,<4
+marshmallow>=3.13,<4

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ from marshmallow_jsonschema import JSONSchema
 
 
 class Address(Schema):
-    id = fields.String(default="no-id")
+    id = fields.String(dump_default="no-id")
     street = fields.String(required=True)
     number = fields.String(required=True)
     city = fields.String(required=True)
@@ -27,7 +27,7 @@ class UserSchema(Schema):
     updated_naive = fields.NaiveDateTime(attribute="updated", dump_only=True)
     updated = fields.DateTime()
     species = fields.String(attribute="SPECIES")
-    id = fields.String(default="no-id")
+    id = fields.String(dump_default="no-id")
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -37,7 +37,7 @@ def test_default():
 
 def test_default_callable_not_serialized():
     class TestSchema(Schema):
-        uid = fields.UUID(default=uuid.uuid4)
+        uid = fields.UUID(dump_default=uuid.uuid4)
 
     schema = TestSchema()
 
@@ -360,7 +360,7 @@ def test_respect_default_for_nested_schema():
     class TestSchema(Schema):
         nested = fields.Nested(
             TestNestedSchema,
-            default=nested_default,
+            dump_default=nested_default,
         )
         yourfield_nested = fields.Integer(required=True)
 


### PR DESCRIPTION
## Summary
- Swaps \`field.default\` reads for \`field.dump_default\` in \`base.py\` (two sites).
- Updates test helpers and one dump test to pass \`dump_default=\` to fields so the test suite stops firing ~350 \`RemovedInMarshmallow4Warning\`s per run.
- Bumps minimum marshmallow to \`>=3.13\` (where \`dump_default\` was introduced). Still pinned \`<4\`.

Picks up the intent of #167 (credit: @stufisher) and extends it to the tests.
Closes #158. Supersedes #167.

Warning count: 366 → 7. The residual warnings come from \`class Meta: ordered = True\` and kwarg-style field metadata — those will be handled in a separate marshmallow-4 prep pass.

## Test plan
- [x] \`pytest\` — 66 passed
- [x] \`mypy\` — clean
- [x] \`black --check .\` — clean
- [ ] CI matrix 3.9–3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)