### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,14 +1,50 @@
-unreleased
-    - Add support for `marshmallow.fields.Enum` (native Enum field added in
-      marshmallow 3.18). Existing `marshmallow_enum.EnumField` support is
-      preserved. #169, #170
-    - Internal: renamed `ALLOW_ENUMS` to `ALLOW_MARSHMALLOW_ENUM` for the
-      third-party package and added `ALLOW_NATIVE_ENUM` for the in-tree
-      field. `ALLOW_ENUMS` is retained as a backward-compatible alias
-      (True when either is active).
-    - Replace deprecated `field.default` reads with `field.dump_default` to
-      silence `RemovedInMarshmallow4Warning`. Minimum supported marshmallow
-      is now 3.13. #158, #167
+0.14.0 (2026-04-19)
+    This is primarily a maintenance release to unbreak installs on
+    modern Python and marshmallow. It intentionally preserves public
+    API behavior; see the "Backward compatibility" notes below.
+
+    New:
+    - Add support for `marshmallow.fields.Enum`, the native Enum field
+      added in marshmallow 3.18. `marshmallow_enum.EnumField` support is
+      preserved; native Enum is preferred when both are present.
+      (#169, #170, #189)
+    - Factor out the `$ref` emitted for nested schemas into a
+      `_schema_base(name)` method so subclasses of `JSONSchema` can
+      override it (e.g. to target a JSON Schema draft other than
+      Draft-07). (#180)
+
+    Fixes / maintenance:
+    - Replace deprecated `pkg_resources.get_distribution` with
+      `importlib.metadata.version`. Removes the runtime dependency on
+      setuptools. (#182, #185)
+    - Pin `marshmallow<4` in requirements. marshmallow 4 removed the
+      private `_Missing` symbol we import, so every fresh install on a
+      machine without a pin was broken. A real marshmallow-4 port is
+      planned for a later release.
+    - Replace `field.default` reads with `field.dump_default` to silence
+      `RemovedInMarshmallow4Warning`. (#158, #167, #190)
+    - CI now tests Python 3.9 - 3.13 and uses current versions of
+      `actions/checkout` and `actions/setup-python`. The mypy workflow
+      was rewritten to actually install the project before type-checking
+      (it had been silently broken). (#183, #188)
+    - Housekeeping: delete dead CodeQL / OSSAR workflows and the
+      redundant `requirements-tox.txt`; rewrite `CONTRIBUTING.md` to
+      match reality; fix an `integer_schema` typo in the union test
+      that was silently passing on the wrong branch; scrub most of the
+      residual `RemovedInMarshmallow4Warning`s emitted by the test
+      suite; correct a stale `Yields` example in the README. (#192,
+      #193, #194)
+
+    Backward compatibility:
+    - Minimum supported Python is now 3.9. Python 3.6 / 3.7 / 3.8 are
+      end-of-life; `pkg_resources` → `importlib.metadata` also requires
+      Python 3.8+. Users on older interpreters should stay on 0.13.0.
+    - Minimum supported marshmallow is now 3.13 (for `dump_default`).
+      marshmallow 3.13 shipped in July 2021.
+    - `marshmallow_jsonschema.base.ALLOW_ENUMS` continues to mean
+      "`marshmallow_enum` is importable", matching its historical
+      semantic. The new `ALLOW_MARSHMALLOW_ENUM` is an alias for it, and
+      `ALLOW_NATIVE_ENUM` is a separate flag for the native Enum field.
 
 0.13.0 (2021-10-21)
     - Fixes to field default #151

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or mobile device).
 
 #### Installation
 
-Requires python>=3.6 and marshmallow>=3.11. (For python 2 & marshmallow 2 support, please use marshmallow-jsonschema<0.11)
+Requires python>=3.9 and marshmallow>=3.13,<4. (For marshmallow 2 support use `marshmallow-jsonschema<0.11`; for Python 3.6-3.8 or marshmallow 3.11-3.12 use `marshmallow-jsonschema<0.14`. marshmallow 4 is not yet supported.)
 
 ```
 pip install marshmallow-jsonschema

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -33,9 +33,10 @@ try:
 except ImportError:
     ALLOW_NATIVE_ENUM = False
 
-# Backward-compatible alias. External code has historically imported
-# `ALLOW_ENUMS` to detect whether *any* enum support is active.
-ALLOW_ENUMS = ALLOW_MARSHMALLOW_ENUM or ALLOW_NATIVE_ENUM
+# Backward-compat alias: historically this meant "marshmallow_enum is
+# importable", and external code has checked it as such. Keep it pointed
+# at the third-party flag so the semantic doesn't shift under callers.
+ALLOW_ENUMS = ALLOW_MARSHMALLOW_ENUM
 
 from .exceptions import UnsupportedValueError
 from .validation import (

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="marshmallow-jsonschema",
-    version="0.13.0",
+    version="0.14.0",
     description="JSON Schema Draft v7 (http://json-schema.org/)"
     " formatting with marshmallow",
     long_description=long_description,


### PR DESCRIPTION
Maintenance release. Unbreaks installs on modern Python + marshmallow, adds native Enum support, and keeps the public API stable.

## Included since 0.13.0
- `pkg_resources` → `importlib.metadata` (#185, closes #182)
- Pin `marshmallow<4` and fix broken mypy workflow (#188)
- CI: drop EOL Python, add 3.12/3.13 (#188)
- Native `marshmallow.fields.Enum` support (#189, closes #169)
- Replace `field.default` reads with `field.dump_default` (#190, closes #158)
- Repo cleanup: drop dead workflows + legacy deps + stale docs (#192)
- Test-suite hygiene + a real union-test bug fix (#193)
- Doc/packaging polish: correct `Yields` example, `__all__`, `MANIFEST.in` (#194)
- This PR: restore `ALLOW_ENUMS` historical semantic, bump version, consolidate CHANGES

## Backward compatibility
- Minimum Python: **3.9** (3.6/3.7/3.8 are EOL; stay on 0.13.0 if stuck on an older interpreter)
- Minimum marshmallow: **3.13** (released July 2021)
- `marshmallow_jsonschema.base.ALLOW_ENUMS` still means "`marshmallow_enum` is importable" — reverted the semantic change from #189 before shipping
- No public exports removed or renamed

## Test plan
- [x] `pytest` — 66 passed
- [x] `pytest -W error::DeprecationWarning` — only `test_nested_context` (out of scope; m4-port work)
- [x] `mypy marshmallow_jsonschema` — clean
- [x] `black --check .` — clean
- [x] Version reads as `0.14.0`, `from marshmallow_jsonschema import *` exposes `__version__` / `__license__`
- [x] CI matrix 3.9–3.13

## Not in this release (deferred)
- marshmallow 4 support (its own dedicated port)
- Tier-2 feature PRs: #181 callable defaults, #99 title/description metadata, #96 anyOf, #95 oneOf fix, #94 preserve property order, #100 data_key for property names, #122 nested allow_none, #118 integer type fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)