### PR TITLE
Test fix-ups from review

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -140,7 +140,6 @@ def _resolve_additional_properties(cls) -> bool:
     elif unknown == INCLUDE:
         return True
     else:
-        # This is probably unreachable as of marshmallow 3.16.0
         raise UnsupportedValueError("Unknown value %s for `unknown`" % unknown)
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -62,7 +62,7 @@ def test_metadata():
 
     class TestSchema(Schema):
         myfield = fields.String(metadata={"foo": "Bar"})
-        yourfield = fields.Integer(required=True, baz="waz")
+        yourfield = fields.Integer(required=True, metadata={"baz": "waz"})
 
     schema = TestSchema()
 
@@ -396,10 +396,14 @@ def test_function():
 
     class FnSchema(Schema):
         fn_str = fields.Function(
-            lambda: "string", required=True, _jsonschema_type_mapping={"type": "string"}
+            lambda: "string",
+            required=True,
+            metadata={"_jsonschema_type_mapping": {"type": "string"}},
         )
         fn_int = fields.Function(
-            lambda: 123, required=True, _jsonschema_type_mapping={"type": "number"}
+            lambda: 123,
+            required=True,
+            metadata={"_jsonschema_type_mapping": {"type": "number"}},
         )
 
     schema = FnSchema()
@@ -446,14 +450,13 @@ def test_unknown_typed_field_throws_valueerror():
         def _serialize(self, value, attr, obj):
             return value
 
-    class UserSchema(Schema):
+    class UserSchemaWithInvalid(Schema):
         favourite_colour = Invalid()
 
-    schema = UserSchema()
-    json_schema = JSONSchema()
+    schema = UserSchemaWithInvalid()
 
     with pytest.raises(UnsupportedValueError):
-        validate_and_dump(json_schema.dump(schema))
+        validate_and_dump(schema)
 
 
 def test_unknown_typed_field():
@@ -516,7 +519,9 @@ def test_metadata_direct_from_field():
 
     class TestSchema(Schema):
         id = fields.Integer(required=True)
-        metadata_field = fields.String(description="Directly on the field!")
+        metadata_field = fields.String(
+            metadata={"description": "Directly on the field!"}
+        )
 
     schema = TestSchema()
 
@@ -622,10 +627,10 @@ def test_datetime_based():
 
 
 def test_sorting_properties():
+    # Field declaration order is preserved by marshmallow itself; what we're
+    # exercising here is JSONSchema's `props_ordered` flag, which gates whether
+    # the dumped properties are sorted (default) or kept in declaration order.
     class TestSchema(Schema):
-        class Meta:
-            ordered = True
-
         d = fields.Str()
         c = fields.Str()
         a = fields.Str()
@@ -685,13 +690,10 @@ def test_enum_based_load_dump_value():
     class TestSchema(Schema):
         enum_prop = EnumField(TestEnum, by_value=True)
 
-    # Should be sorting of fields
     schema = TestSchema()
 
-    json_schema = JSONSchema()
-
     with pytest.raises(NotImplementedError):
-        validate_and_dump(json_schema.dump(schema))
+        validate_and_dump(schema)
 
 
 @pytest.mark.skipif(
@@ -733,10 +735,9 @@ def test_native_enum_based_by_value():
         enum_prop = NativeEnumField(TestEnum, by_value=True)
 
     schema = TestSchema()
-    json_schema = JSONSchema()
 
     with pytest.raises(NotImplementedError):
-        validate_and_dump(json_schema.dump(schema))
+        validate_and_dump(schema)
 
 
 def test_union_based():
@@ -760,7 +761,7 @@ def test_union_based():
     assert len(data["definitions"]["TestSchema"]["properties"]["union_prop"]) == 1
 
     string_schema = {"type": "string", "title": ""}
-    integer_schema = {"type": "string", "title": ""}
+    integer_schema = {"type": "integer", "title": ""}
     referenced_nested_schema = {
         "type": "object",
         "$ref": "#/definitions/TestNestedSchema",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,9 +38,6 @@ def test_length_validator_error():
     class BadSchema(Schema):
         bob = fields.Integer(validate=validate.Length(min=1, max=3))
 
-        class Meta:
-            strict = True
-
     schema = BadSchema()
     json_schema = JSONSchema()
 


### PR DESCRIPTION
Small batch of unambiguous test improvements found during a closer review of the test suite.

## Real bug
- **\`test_union_based\` integer-branch assertion was silently broken.** \`integer_schema\` was set to \`{\"type\": \"string\", \"title\": \"\"}\` - byte-identical to \`string_schema\` - so \`assert integer_schema in anyOf\` was passing on the string match. Set type to \`\"integer\"\`. (test_dump.py:763)

## Hygiene
- **Stop the double-dump pattern in 3 \`pytest.raises\` blocks.** \`validate_and_dump(json_schema.dump(schema))\` worked only because the exception fired inside the inner call before the outer ever ran. Replace with \`validate_and_dump(schema)\`. Affects \`test_unknown_typed_field_throws_valueerror\`, \`test_enum_based_load_dump_value\`, \`test_native_enum_based_by_value\`.
- **Rename shadowing \`UserSchema\`.** The local class in \`test_unknown_typed_field_throws_valueerror\` shadowed the package-level \`UserSchema\` imported at the top of the file. Renamed to \`UserSchemaWithInvalid\`.

## Deprecation cleanup
- **4 sites switched from kwarg-as-metadata to \`metadata={...}\`** (\`test_metadata\`, \`test_function\` x2, \`test_metadata_direct_from_field\`). These were the source of most residual \`RemovedInMarshmallow4Warning\`s.
- **Drop \`class Meta: ordered = True\`** from \`test_sorting_properties\`. Field declaration order is preserved by marshmallow itself; the test is really exercising \`JSONSchema\`'s own \`props_ordered\` flag. Added a comment.
- **Drop \`class Meta: strict = True\`** from \`test_length_validator_error\`. Removed in marshmallow 3 (validation is always strict).

## Dead comment
- Strip a stale \"probably unreachable as of marshmallow 3.16.0\" comment in \`base.py\`. We now require \`>=3.13\` so the branch can fire on 3.13-3.15.

## Net effect
- Warning count: **7 → 2** per pytest run. The two remaining come from \`test_nested_context\`'s use of \`Schema(context={...})\` - that migration belongs with the marshmallow-4 port (needs \`contextvars.ContextVar\`).
- 1 real test bug fixed.
- ~3 lines of dead code/comments removed.

## Test plan
- [x] \`pytest\` - 66 passed
- [x] \`pytest -W error::DeprecationWarning\` - only \`test_nested_context\` fails (out of scope)
- [x] \`mypy\` - clean
- [x] \`black --check .\` - clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)