### PR TITLE
Add jsonschema-validation regression test for Integer fields

### DIFF
--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,6 +1,7 @@
 import uuid
 from enum import Enum
 
+import jsonschema
 import pytest
 from marshmallow import Schema, fields, validate
 from marshmallow_enum import EnumField
@@ -694,6 +695,25 @@ def test_enum_based_load_dump_value():
 
     with pytest.raises(NotImplementedError):
         validate_and_dump(schema)
+
+
+def test_integer_field_emits_integer_type():
+    """Regression test for #117 — Integer fields must emit `type: integer`,
+    not `type: number` with a `format: integer`. Otherwise floats validate
+    against integer fields."""
+
+    class Foo(Schema):
+        bar = fields.Integer()
+
+    schema = JSONSchema().dump(Foo())
+    bar_property = schema["definitions"]["Foo"]["properties"]["bar"]
+
+    assert bar_property["type"] == "integer"
+    assert "format" not in bar_property
+
+    jsonschema.validate({"bar": 1}, schema)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"bar": 1.1}, schema)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Picks up the test portion of #118 (credit: @SteadBytes). The fix itself — mapping `int` to `{"type": "integer"}` instead of `{"type": "number", "format": "integer"}` — already landed in 0.13.0 via #152.

The new test goes one step further than the rest of the suite by calling `jsonschema.validate(...)` against a generated schema with both a valid integer instance and a fractional float, asserting the float is rejected. Guards against accidental regressions where Integer fields silently start accepting floats.

Closes #118.

## Test plan
- [x] `pytest` — 67 passed (66 prior + 1 new)
- [x] `black --check .` — clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)