### PR TITLE
Honor allow_none on Nested fields

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -367,6 +367,9 @@ class JSONSchema(Schema):
         if field.dump_default is not missing and not callable(field.dump_default):
             schema["default"] = nested_instance.dump(field.dump_default)
 
+        if field.allow_none:
+            schema = {"anyOf": [schema, {"type": "null"}]}
+
         if field.many:
             schema = {
                 "type": "array" if field.required else ["array", "null"],

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -534,6 +534,27 @@ def test_metadata_direct_from_field():
     }
 
 
+def test_allow_none_on_nested():
+    """A Nested field with allow_none=True should produce anyOf [$ref, null]."""
+
+    class ChildSchema(Schema):
+        id = fields.Integer(required=True)
+
+    class TestSchema(Schema):
+        id = fields.Integer(required=True)
+        nested_fld = fields.Nested(ChildSchema, allow_none=True)
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["nested_fld"] == {
+        "anyOf": [
+            {"type": "object", "$ref": "#/definitions/ChildSchema"},
+            {"type": "null"},
+        ]
+    }
+
+
 def test_allow_none():
     """A field with allow_none set to True should have type null as additional."""
 


### PR DESCRIPTION
Picks up the `allow_none` portion of #122 (credit: @avilaton).

Currently `_from_nested_schema` ignores `allow_none` entirely, so a Nested field declared with `allow_none=True` produces a schema that rejects `None`. This wraps the nested schema in `anyOf: [<nested>, {"type": "null"}]` when the field has `allow_none=True`.

Placed before the `field.many` block so an `allow_none` on `many=True` describes nullable *items* rather than a nullable outer array (the not-required + many case already handles a nullable outer via `["array", "null"]`).

Skips the unrelated portion of #122 that removed `"type": "object"` from the inline `$ref` schema — that change is BC-breaking and conflicts with the `_schema_base` hook added in #180.

Closes #121, closes #101.

## Test plan
- [x] `pytest tests/test_dump.py::test_allow_none_on_nested` — passes
- [x] `pytest -q` — 67 passed (66 prior + 1 new)
- [x] `mypy marshmallow_jsonschema` — clean
- [x] `black --check .` — clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)