### PR TITLE
Add ContainsOnly validator handler

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -40,6 +40,7 @@ ALLOW_ENUMS = ALLOW_MARSHMALLOW_ENUM
 
 from .exceptions import UnsupportedValueError
 from .validation import (
+    handle_contains_only,
     handle_equal,
     handle_length,
     handle_one_of,
@@ -113,6 +114,7 @@ if ALLOW_NATIVE_ENUM:
 
 
 FIELD_VALIDATORS = {
+    validate.ContainsOnly: handle_contains_only,
     validate.Equal: handle_equal,
     validate.Length: handle_length,
     validate.OneOf: handle_one_of,

--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -75,6 +75,42 @@ def handle_one_of(schema, field, validator, parent_schema):
     return schema
 
 
+def handle_contains_only(schema, field, validator, parent_schema):
+    """Adds the validation logic for ``marshmallow.validate.ContainsOnly`` by
+    constraining each item of an array field to one of the allowed choices.
+
+    Only fires for array (List) fields; bails out cleanly for non-array fields
+    or empty choice sets so unrelated schemas pass through unchanged.
+
+    Args:
+        schema (dict): The original JSON schema we generated.
+        field (fields.Field): The field that generated the original schema.
+        validator (marshmallow.validate.ContainsOnly): The validator attached
+            to the field.
+        parent_schema (marshmallow.Schema): The Schema instance that the field
+            belongs to.
+
+    Returns:
+        dict: A possibly-new JSON Schema that has been post-processed.
+    """
+    if schema.get("type") != "array":
+        return schema
+
+    choices = field._serialize(validator.choices, field.name, None)
+    if not choices:
+        return schema
+
+    item_type = schema["items"].get("type", "string")
+    labels = validator.labels if validator.labels else choices
+    schema["items"]["anyOf"] = [
+        {"type": item_type, "title": label, "const": choice}
+        for choice, label in zip(choices, labels)
+    ]
+    schema["uniqueItems"] = True
+
+    return schema
+
+
 def handle_equal(schema, field, validator, parent_schema):
     """Adds the validation logic for ``marshmallow.validate.Equal`` by setting
     the JSONSchema `enum` property to value of the validator.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import pytest
 from marshmallow import Schema, fields, validate
-from marshmallow.validate import OneOf, Range
+from marshmallow.validate import ContainsOnly, OneOf, Range
 from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
@@ -75,6 +75,58 @@ def test_one_of_empty_enum():
     foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
     assert foo_property["enum"] == []
     assert foo_property["enumNames"] == []
+
+
+def test_contains_only_validator():
+    class TestSchema(Schema):
+        foo = fields.List(
+            fields.String,
+            validate=ContainsOnly(
+                choices=["apple", "lime", "orange"],
+                labels=["Apple", "Lime", "Orange"],
+            ),
+        )
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert foo_property["uniqueItems"] is True
+    assert foo_property["items"]["anyOf"] == [
+        {"type": "string", "title": "Apple", "const": "apple"},
+        {"type": "string", "title": "Lime", "const": "lime"},
+        {"type": "string", "title": "Orange", "const": "orange"},
+    ]
+
+
+def test_contains_only_empty_choices():
+    """Empty choices should not emit an anyOf or uniqueItems."""
+
+    class TestSchema(Schema):
+        foo = fields.List(fields.String, validate=ContainsOnly(choices=[]))
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert "anyOf" not in foo_property["items"]
+    assert "uniqueItems" not in foo_property
+
+
+def test_contains_only_on_non_array_field_is_noop():
+    """ContainsOnly on a non-array field shouldn't crash or wrap items."""
+
+    class TestSchema(Schema):
+        foo = fields.String(
+            validate=ContainsOnly(choices=["a", "b"], labels=["A", "B"])
+        )
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert "uniqueItems" not in foo_property
+    assert "items" not in foo_property
 
 
 def test_range():


### PR DESCRIPTION
Picks up #96 (credit: @Lundalogik). Adds support for emitting JSON Schema constraints from `marshmallow.validate.ContainsOnly`.

## Behavior
- For a `List` field validated by `ContainsOnly`, each item is constrained to one of the allowed choices via `items.anyOf` of `const` entries.
- `uniqueItems: true` is set on the array. `ContainsOnly` doesn't strictly require uniqueness, but in practice it's a multi-select pattern and treating items as unique matches typical UI semantics. (Open to revisiting if anyone finds the duplicate-allowing case in the wild.)
- Empty choices and non-array fields bail out cleanly so unrelated schemas pass through unchanged.

Renamed `handle_any_of` → `handle_contains_only` so the function name describes the input validator instead of the output keyword (matching `handle_one_of`, `handle_range`, etc.).

## Test plan
- [x] 3 new tests under `test_contains_only_*` pass
- [x] full suite: 69 passed
- [x] `mypy` / `black` clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)