### PR TITLE
Propagate props_ordered to nested schemas

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -341,7 +341,9 @@ class JSONSchema(Schema):
         # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
         # put it in our list of schema defs
         if name not in self._nested_schema_classes and name != outer_name:
-            wrapped_nested = self.__class__(nested=True)
+            wrapped_nested = self.__class__(
+                nested=True, props_ordered=self.props_ordered
+            )
             wrapped_dumped = wrapped_nested.dump(nested_instance)
 
             wrapped_dumped["additionalProperties"] = _resolve_additional_properties(

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -626,6 +626,29 @@ def test_datetime_based():
     }
 
 
+def test_props_ordered_propagates_to_nested():
+    """props_ordered=True on the outer JSONSchema must apply to nested
+    schemas too. Regression for #109."""
+
+    class Inner(Schema):
+        z = fields.Str()
+        y = fields.Str()
+        x = fields.Str()
+
+    class Outer(Schema):
+        d = fields.Str()
+        c = fields.Str()
+        a = fields.Str()
+        nested = fields.Nested(Inner)
+
+    dumped = JSONSchema(props_ordered=True).dump(Outer())
+    outer_props = list(dumped["definitions"]["Outer"]["properties"].keys())
+    inner_props = list(dumped["definitions"]["Inner"]["properties"].keys())
+
+    assert outer_props == ["d", "c", "a", "nested"]
+    assert inner_props == ["z", "y", "x"]
+
+
 def test_sorting_properties():
     # Field declaration order is preserved by marshmallow itself; what we're
     # exercising here is JSONSchema's `props_ordered` flag, which gates whether


### PR DESCRIPTION
Picks up #129 (credit: @sdefauw). Regression for #109.

## The bug
When `JSONSchema(props_ordered=True)` processes a nested field, it instantiates a new JSONSchema for the nested schema via `self.__class__(nested=True)` — which defaults `props_ordered` back to `False` and loses the outer caller's preference. Nested schema fields then get sorted alphabetically regardless of what the caller asked for.

## The fix
Pass `props_ordered=self.props_ordered` through to the nested instance so the setting applies uniformly.

Closes #109.

## Test plan
- [x] `pytest tests/test_dump.py::test_props_ordered_propagates_to_nested` — passes
- [x] full suite: 67 passed
- [x] `black --check .` — clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)