### PR TITLE
Add `definitions_path` constructor argument

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -162,6 +162,7 @@ class JSONSchema(Schema):
         self._nested_schema_classes: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
         self.nested = kwargs.pop("nested", False)
         self.props_ordered = kwargs.pop("props_ordered", False)
+        self.definitions_path = kwargs.pop("definitions_path", "definitions")
         setattr(self.opts, "ordered", self.props_ordered)
         super().__init__(*args, **kwargs)
 
@@ -341,7 +342,9 @@ class JSONSchema(Schema):
         # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
         # put it in our list of schema defs
         if name not in self._nested_schema_classes and name != outer_name:
-            wrapped_nested = self.__class__(nested=True)
+            wrapped_nested = self.__class__(
+                nested=True, definitions_path=self.definitions_path
+            )
             wrapped_dumped = wrapped_nested.dump(nested_instance)
 
             wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
@@ -376,7 +379,10 @@ class JSONSchema(Schema):
         return schema
 
     def _schema_base(self, name):
-        return {"type": "object", "$ref": "#/definitions/{}".format(name)}
+        return {
+            "type": "object",
+            "$ref": "#/{}/{}".format(self.definitions_path, name),
+        }
 
     def dump(self, obj, **kwargs):
         """Take obj for later use: using class name to namespace definition."""
@@ -397,7 +403,7 @@ class JSONSchema(Schema):
         self._nested_schema_classes[name] = data
         root = {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "definitions": self._nested_schema_classes,
-            "$ref": "#/definitions/{name}".format(name=name),
+            self.definitions_path: self._nested_schema_classes,
+            "$ref": "#/{path}/{name}".format(path=self.definitions_path, name=name),
         }
         return root

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -626,6 +626,29 @@ def test_datetime_based():
     }
 
 
+def test_definitions_path_custom():
+    """The `definitions_path` constructor argument should reshape both the
+    root key holding nested definitions and the emitted $ref paths.
+    Useful for targeting OpenAPI, which uses `components/schemas` instead
+    of `definitions`."""
+
+    class Inner(Schema):
+        foo = fields.Integer()
+
+    class Outer(Schema):
+        inner = fields.Nested(Inner)
+
+    dumped = JSONSchema(definitions_path="components/schemas").dump(Outer())
+
+    assert "definitions" not in dumped
+    assert "components/schemas" in dumped
+    assert dumped["$ref"] == "#/components/schemas/Outer"
+    assert (
+        dumped["components/schemas"]["Outer"]["properties"]["inner"]["$ref"]
+        == "#/components/schemas/Inner"
+    )
+
+
 def test_sorting_properties():
     # Field declaration order is preserved by marshmallow itself; what we're
     # exercising here is JSONSchema's `props_ordered` flag, which gates whether


### PR DESCRIPTION
Picks up #179 (credit: @mrtedn21).

## Why
JSONSchema hard-codes the JSON pointer path `#/definitions/...` for all nested schema refs. That's fine for a standalone JSON Schema, but breaks when the output is embedded in OpenAPI / Swagger, which uses `#/components/schemas/...`.

## Change
Adds a `definitions_path` constructor kwarg that controls both the root key holding nested definitions and every `$ref` emitted. Default is `"definitions"` so there's no BC impact for existing callers.

```python
JSONSchema(definitions_path="components/schemas").dump(MySchema())
# → {"$ref": "#/components/schemas/MySchema", "components/schemas": {...}, ...}
```

- The `_schema_base` hook (added in #180) now honors `definitions_path` so subclasses overriding it get the right path for free.
- `definitions_path` propagates to nested JSONSchema instances via the same `self.__class__(nested=True, ...)` pattern used for `props_ordered` (see #198).

## Test plan
- [x] `pytest tests/test_dump.py::test_definitions_path_custom` — passes
- [x] full suite: 67 passed (default path unchanged)
- [x] `mypy` / `black` clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)