### PR TITLE
Tier-2 batch: 9 features + fixes from the open-PR backlog

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -3,7 +3,7 @@ import decimal
 import json
 import uuid
 from enum import Enum
-from inspect import isclass
+from inspect import isclass, signature
 import typing
 
 from marshmallow import fields, missing, Schema, validate
@@ -306,6 +306,22 @@ class JSONSchema(Schema):
 
         raise UnsupportedValueError("unsupported field type %s" % field)
 
+    def _call_jsonschema_type_mapping(self, obj, field):
+        """Invoke the field's ``_jsonschema_type_mapping``, optionally passing
+        through the JSONSchema instance and the schema obj.
+
+        Existing no-arg implementations continue to work unchanged. Custom
+        field types that explicitly declare extra parameters can introspect
+        ``self`` to call back into the JSONSchema machinery - useful for
+        wrapper-style fields that need to emit a $ref to a recursive schema.
+        """
+        mapping = field._jsonschema_type_mapping
+        # len(sig.parameters) excludes `self` because we're looking at the
+        # bound method's signature.
+        if len(signature(mapping).parameters) == 2:
+            return mapping(self, obj)
+        return mapping()
+
     def _apply_custom_field_attributes(self, schema, field):
         """Apply field-level attributes (title/description metadata, default,
         dump_only) to a schema produced by a ``_jsonschema_type_mapping``.
@@ -331,7 +347,7 @@ class JSONSchema(Schema):
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
         if hasattr(field, "_jsonschema_type_mapping"):
-            schema = field._jsonschema_type_mapping()
+            schema = self._call_jsonschema_type_mapping(obj, field)
             self._apply_custom_field_attributes(schema, field)
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -306,12 +306,36 @@ class JSONSchema(Schema):
 
         raise UnsupportedValueError("unsupported field type %s" % field)
 
+    def _apply_custom_field_attributes(self, schema, field):
+        """Apply field-level attributes (title/description metadata, default,
+        dump_only) to a schema produced by a ``_jsonschema_type_mapping``.
+
+        `_from_python_type` applies these itself; custom-typed fields bypass
+        that path, so without this they'd silently lose their metadata.
+        """
+        if field.dump_only:
+            schema["readOnly"] = True
+
+        if field.dump_default is not missing and not callable(field.dump_default):
+            if _is_json_serializable(field.dump_default):
+                schema["default"] = field.dump_default
+
+        # NOTE: doubled up to maintain backwards compatibility
+        metadata = field.metadata.get("metadata", {})
+        metadata.update(field.metadata)
+        for md_key, md_val in metadata.items():
+            if md_key in ("metadata", "name", "_jsonschema_type_mapping"):
+                continue
+            schema.setdefault(md_key, md_val)
+
     def _get_schema_for_field(self, obj, field):
         """Get schema and validators for field."""
         if hasattr(field, "_jsonschema_type_mapping"):
             schema = field._jsonschema_type_mapping()
+            self._apply_custom_field_attributes(schema, field)
         elif "_jsonschema_type_mapping" in field.metadata:
             schema = field.metadata["_jsonschema_type_mapping"]
+            self._apply_custom_field_attributes(schema, field)
         else:
             if isinstance(field, fields.Nested):
                 # Special treatment for nested fields.

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import json
 import uuid
 from enum import Enum
 from inspect import isclass
@@ -123,6 +124,22 @@ FIELD_VALIDATORS = {
 }
 
 
+def _is_json_serializable(value) -> bool:
+    """Return True if `value` can be emitted into a JSON schema directly.
+
+    Used to guard `default` emission: marshmallow accepts Python objects
+    (UUID, datetime, etc.) as dump_default values, but those objects can
+    only be serialized by marshmallow's own field-specific logic - they
+    aren't valid JSON literals, so including them as `default` produces
+    a schema that can't round-trip through `json.dumps`.
+    """
+    try:
+        json.dumps(value)
+        return True
+    except TypeError:
+        return False
+
+
 def _resolve_additional_properties(cls) -> bool:
     meta = cls.Meta
 
@@ -212,7 +229,8 @@ class JSONSchema(Schema):
             json_schema["readOnly"] = True
 
         if field.dump_default is not missing and not callable(field.dump_default):
-            json_schema["default"] = field.dump_default
+            if _is_json_serializable(field.dump_default):
+                json_schema["default"] = field.dump_default
 
         if ALLOW_NATIVE_ENUM and isinstance(field, NativeEnumField):
             json_schema["enum"] = self._get_native_enum_values(field)

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -40,6 +40,7 @@ ALLOW_ENUMS = ALLOW_MARSHMALLOW_ENUM
 
 from .exceptions import UnsupportedValueError
 from .validation import (
+    handle_contains_only,
     handle_equal,
     handle_length,
     handle_one_of,
@@ -113,6 +114,7 @@ if ALLOW_NATIVE_ENUM:
 
 
 FIELD_VALIDATORS = {
+    validate.ContainsOnly: handle_contains_only,
     validate.Equal: handle_equal,
     validate.Length: handle_length,
     validate.OneOf: handle_one_of,

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -164,6 +164,7 @@ class JSONSchema(Schema):
         self._nested_schema_classes: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
         self.nested = kwargs.pop("nested", False)
         self.props_ordered = kwargs.pop("props_ordered", False)
+        self.definitions_path = kwargs.pop("definitions_path", "definitions")
         setattr(self.opts, "ordered", self.props_ordered)
         super().__init__(*args, **kwargs)
 
@@ -344,7 +345,9 @@ class JSONSchema(Schema):
         # put it in our list of schema defs
         if name not in self._nested_schema_classes and name != outer_name:
             wrapped_nested = self.__class__(
-                nested=True, props_ordered=self.props_ordered
+                nested=True,
+                props_ordered=self.props_ordered,
+                definitions_path=self.definitions_path,
             )
             wrapped_dumped = wrapped_nested.dump(nested_instance)
 
@@ -383,7 +386,10 @@ class JSONSchema(Schema):
         return schema
 
     def _schema_base(self, name):
-        return {"type": "object", "$ref": "#/definitions/{}".format(name)}
+        return {
+            "type": "object",
+            "$ref": "#/{}/{}".format(self.definitions_path, name),
+        }
 
     def dump(self, obj, **kwargs):
         """Take obj for later use: using class name to namespace definition."""
@@ -404,7 +410,7 @@ class JSONSchema(Schema):
         self._nested_schema_classes[name] = data
         root = {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "definitions": self._nested_schema_classes,
-            "$ref": "#/definitions/{name}".format(name=name),
+            self.definitions_path: self._nested_schema_classes,
+            "$ref": "#/{path}/{name}".format(path=self.definitions_path, name=name),
         }
         return root

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -343,7 +343,9 @@ class JSONSchema(Schema):
         # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
         # put it in our list of schema defs
         if name not in self._nested_schema_classes and name != outer_name:
-            wrapped_nested = self.__class__(nested=True)
+            wrapped_nested = self.__class__(
+                nested=True, props_ordered=self.props_ordered
+            )
             wrapped_dumped = wrapped_nested.dump(nested_instance)
 
             wrapped_dumped["additionalProperties"] = _resolve_additional_properties(

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -367,6 +367,9 @@ class JSONSchema(Schema):
         if field.dump_default is not missing and not callable(field.dump_default):
             schema["default"] = nested_instance.dump(field.dump_default)
 
+        if field.allow_none:
+            schema = {"anyOf": [schema, {"type": "null"}]}
+
         if field.many:
             schema = {
                 "type": "array" if field.required else ["array", "null"],

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -163,6 +163,19 @@ def _resolve_additional_properties(cls) -> bool:
         raise UnsupportedValueError("Unknown value %s for `unknown`" % unknown)
 
 
+def _resolve_schema_meta_string(cls, name):
+    """Read a string option off ``cls.Meta`` and validate it. Returns None
+    when the option isn't set. Raises ``UnsupportedValueError`` if present
+    but not a str, so callers get a clear error instead of a silently
+    malformed schema."""
+    value = getattr(cls.Meta, name, None)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise UnsupportedValueError("`{}` must be a str".format(name))
+    return value
+
+
 class JSONSchema(Schema):
     """Converts to JSONSchema as defined by http://json-schema.org/."""
 
@@ -412,6 +425,10 @@ class JSONSchema(Schema):
             wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
                 nested_cls
             )
+            for meta_key in ("title", "description"):
+                value = _resolve_schema_meta_string(nested_cls, meta_key)
+                if value is not None:
+                    wrapped_dumped[meta_key] = value
 
             self._nested_schema_classes[name] = wrapped_dumped
 
@@ -464,6 +481,10 @@ class JSONSchema(Schema):
         name = cls.__name__
 
         data["additionalProperties"] = _resolve_additional_properties(cls)
+        for meta_key in ("title", "description"):
+            value = _resolve_schema_meta_string(cls, meta_key)
+            if value is not None:
+                data[meta_key] = value
 
         self._nested_schema_classes[name] = data
         root = {

--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -75,6 +75,42 @@ def handle_one_of(schema, field, validator, parent_schema):
     return schema
 
 
+def handle_contains_only(schema, field, validator, parent_schema):
+    """Adds the validation logic for ``marshmallow.validate.ContainsOnly`` by
+    constraining each item of an array field to one of the allowed choices.
+
+    Only fires for array (List) fields; bails out cleanly for non-array fields
+    or empty choice sets so unrelated schemas pass through unchanged.
+
+    Args:
+        schema (dict): The original JSON schema we generated.
+        field (fields.Field): The field that generated the original schema.
+        validator (marshmallow.validate.ContainsOnly): The validator attached
+            to the field.
+        parent_schema (marshmallow.Schema): The Schema instance that the field
+            belongs to.
+
+    Returns:
+        dict: A possibly-new JSON Schema that has been post-processed.
+    """
+    if schema.get("type") != "array":
+        return schema
+
+    choices = field._serialize(validator.choices, field.name, None)
+    if not choices:
+        return schema
+
+    item_type = schema["items"].get("type", "string")
+    labels = validator.labels if validator.labels else choices
+    schema["items"]["anyOf"] = [
+        {"type": item_type, "title": label, "const": choice}
+        for choice, label in zip(choices, labels)
+    ]
+    schema["uniqueItems"] = True
+
+    return schema
+
+
 def handle_equal(schema, field, validator, parent_schema):
     """Adds the validation logic for ``marshmallow.validate.Equal`` by setting
     the JSONSchema `enum` property to value of the validator.

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -83,6 +83,60 @@ def test_additional_properties_from_nested_meta(additional_properties_value):
     )
 
 
+def test_schema_level_title_propagates():
+    class TestSchema(Schema):
+        class Meta:
+            title = "My Nice Title"
+
+        foo = fields.Integer()
+
+    dumped = validate_and_dump(TestSchema())
+    assert dumped["definitions"]["TestSchema"]["title"] == "My Nice Title"
+
+
+def test_schema_level_description_propagates():
+    class TestSchema(Schema):
+        class Meta:
+            description = "My lengthy description."
+
+        foo = fields.Integer()
+
+    dumped = validate_and_dump(TestSchema())
+    assert (
+        dumped["definitions"]["TestSchema"]["description"] == "My lengthy description."
+    )
+
+
+def test_schema_level_meta_string_on_nested():
+    class TestNestedSchema(Schema):
+        class Meta:
+            title = "Inner Title"
+            description = "Inner description."
+
+        foo = fields.Integer()
+
+    class TestSchema(Schema):
+        nested = fields.Nested(TestNestedSchema())
+
+    dumped = validate_and_dump(TestSchema())
+    nested_def = dumped["definitions"]["TestNestedSchema"]
+    assert nested_def["title"] == "Inner Title"
+    assert nested_def["description"] == "Inner description."
+
+
+@pytest.mark.parametrize("meta_key", ("title", "description"))
+def test_schema_level_meta_string_rejects_non_str(meta_key):
+    class TestSchema(Schema):
+        foo = fields.Integer()
+
+    setattr(TestSchema.Meta, meta_key, 123)
+    try:
+        with pytest.raises(UnsupportedValueError):
+            JSONSchema().dump(TestSchema())
+    finally:
+        delattr(TestSchema.Meta, meta_key)
+
+
 @pytest.mark.parametrize(
     "unknown_value, additional_properties",
     ((RAISE, False), (INCLUDE, True), (EXCLUDE, False)),

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -648,6 +648,29 @@ def test_datetime_based():
     }
 
 
+def test_props_ordered_propagates_to_nested():
+    """props_ordered=True on the outer JSONSchema must apply to nested
+    schemas too. Regression for #109."""
+
+    class Inner(Schema):
+        z = fields.Str()
+        y = fields.Str()
+        x = fields.Str()
+
+    class Outer(Schema):
+        d = fields.Str()
+        c = fields.Str()
+        a = fields.Str()
+        nested = fields.Nested(Inner)
+
+    dumped = JSONSchema(props_ordered=True).dump(Outer())
+    outer_props = list(dumped["definitions"]["Outer"]["properties"].keys())
+    inner_props = list(dumped["definitions"]["Inner"]["properties"].keys())
+
+    assert outer_props == ["d", "c", "a", "nested"]
+    assert inner_props == ["z", "y", "x"]
+
+
 def test_sorting_properties():
     # Field declaration order is preserved by marshmallow itself; what we're
     # exercising here is JSONSchema's `props_ordered` flag, which gates whether

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -671,6 +671,29 @@ def test_props_ordered_propagates_to_nested():
     assert inner_props == ["z", "y", "x"]
 
 
+def test_definitions_path_custom():
+    """The `definitions_path` constructor argument should reshape both the
+    root key holding nested definitions and the emitted $ref paths.
+    Useful for targeting OpenAPI, which uses `components/schemas` instead
+    of `definitions`."""
+
+    class Inner(Schema):
+        foo = fields.Integer()
+
+    class Outer(Schema):
+        inner = fields.Nested(Inner)
+
+    dumped = JSONSchema(definitions_path="components/schemas").dump(Outer())
+
+    assert "definitions" not in dumped
+    assert "components/schemas" in dumped
+    assert dumped["$ref"] == "#/components/schemas/Outer"
+    assert (
+        dumped["components/schemas"]["Outer"]["properties"]["inner"]["$ref"]
+        == "#/components/schemas/Inner"
+    )
+
+
 def test_sorting_properties():
     # Field declaration order is preserved by marshmallow itself; what we're
     # exercising here is JSONSchema's `props_ordered` flag, which gates whether

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -525,6 +525,31 @@ def test_custom_field_honors_metadata_and_default():
     }
 
 
+def test_custom_field_jsonschema_type_mapping_accepts_context():
+    """A custom field whose `_jsonschema_type_mapping` accepts
+    `(self, json_schema, obj)` receives the JSONSchema instance and the
+    schema obj, letting it call back into the dumping machinery. Used for
+    wrapper-style fields that need to emit a $ref to a recursive schema.
+    Regression for #165."""
+
+    class NoOpWrapper(fields.Field):
+        def __init__(self, field, **kwargs):
+            self.field = field
+            super().__init__(**kwargs)
+
+        def _jsonschema_type_mapping(self, json_schema, obj):
+            return json_schema._get_schema_for_field(obj, self.field)
+
+    class ContrivedSchema(Schema):
+        recursive = NoOpWrapper(fields.Nested("ContrivedSchema"))
+
+    dumped = validate_and_dump(ContrivedSchema())
+    assert dumped["definitions"]["ContrivedSchema"]["properties"]["recursive"] == {
+        "type": "object",
+        "$ref": "#/definitions/ContrivedSchema",
+    }
+
+
 def test_field_subclass():
     """JSON schema generation should not fail on sublcass marshmallow field."""
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -36,6 +36,22 @@ def test_default():
     assert props["id"]["default"] == "no-id"
 
 
+def test_default_nonserializable_not_emitted():
+    """A non-callable dump_default whose Python value isn't JSON-serializable
+    must not be emitted. Otherwise the schema dict can't round-trip through
+    `json.dumps`. Regression for #181."""
+    import json
+
+    class TestSchema(Schema):
+        uid = fields.UUID(dump_default=uuid.uuid4())
+
+    dumped = validate_and_dump(TestSchema())
+
+    props = dumped["definitions"]["TestSchema"]["properties"]
+    assert "default" not in props["uid"]
+    json.dumps(dumped)
+
+
 def test_default_callable_not_serialized():
     class TestSchema(Schema):
         uid = fields.UUID(dump_default=uuid.uuid4)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,6 +1,7 @@
 import uuid
 from enum import Enum
 
+import jsonschema
 import pytest
 from marshmallow import Schema, fields, validate
 from marshmallow_enum import EnumField
@@ -694,6 +695,25 @@ def test_enum_based_load_dump_value():
 
     with pytest.raises(NotImplementedError):
         validate_and_dump(schema)
+
+
+def test_integer_field_emits_integer_type():
+    """Regression test for #117 — Integer fields must emit `type: integer`,
+    not `type: number` with a `format: integer`. Otherwise floats validate
+    against integer fields."""
+
+    class Foo(Schema):
+        bar = fields.Integer()
+
+    schema = JSONSchema().dump(Foo())
+    bar_property = schema["definitions"]["Foo"]["properties"]["bar"]
+
+    assert bar_property["type"] == "integer"
+    assert "format" not in bar_property
+
+    jsonschema.validate({"bar": 1}, schema)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"bar": 1.1}, schema)
 
 
 @pytest.mark.skipif(

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -535,6 +535,27 @@ def test_metadata_direct_from_field():
     }
 
 
+def test_allow_none_on_nested():
+    """A Nested field with allow_none=True should produce anyOf [$ref, null]."""
+
+    class ChildSchema(Schema):
+        id = fields.Integer(required=True)
+
+    class TestSchema(Schema):
+        id = fields.Integer(required=True)
+        nested_fld = fields.Nested(ChildSchema, allow_none=True)
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    assert dumped["definitions"]["TestSchema"]["properties"]["nested_fld"] == {
+        "anyOf": [
+            {"type": "object", "$ref": "#/definitions/ChildSchema"},
+            {"type": "null"},
+        ]
+    }
+
+
 def test_allow_none():
     """A field with allow_none set to True should have type null as additional."""
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -501,6 +501,30 @@ def test_unknown_typed_field():
     }
 
 
+def test_custom_field_honors_metadata_and_default():
+    """Fields with `_jsonschema_type_mapping` historically lost their
+    `metadata={...}` content and their `dump_default`. Regression for #21."""
+
+    class Colour(fields.Field):
+        def _jsonschema_type_mapping(self):
+            return {"type": "string"}
+
+    class TestSchema(Schema):
+        favourite_colour = Colour(
+            dump_default="#ffffff",
+            metadata={"description": "User's favourite colour", "title": "Colour"},
+        )
+
+    dumped = validate_and_dump(TestSchema())
+    prop = dumped["definitions"]["TestSchema"]["properties"]["favourite_colour"]
+    assert prop == {
+        "type": "string",
+        "default": "#ffffff",
+        "description": "User's favourite colour",
+        "title": "Colour",
+    }
+
+
 def test_field_subclass():
     """JSON schema generation should not fail on sublcass marshmallow field."""
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import pytest
 from marshmallow import Schema, fields, validate
-from marshmallow.validate import OneOf, Range
+from marshmallow.validate import ContainsOnly, OneOf, Range
 from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
@@ -75,6 +75,58 @@ def test_one_of_empty_enum():
     foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
     assert foo_property["enum"] == []
     assert foo_property["enumNames"] == []
+
+
+def test_contains_only_validator():
+    class TestSchema(Schema):
+        foo = fields.List(
+            fields.String,
+            validate=ContainsOnly(
+                choices=["apple", "lime", "orange"],
+                labels=["Apple", "Lime", "Orange"],
+            ),
+        )
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert foo_property["uniqueItems"] is True
+    assert foo_property["items"]["anyOf"] == [
+        {"type": "string", "title": "Apple", "const": "apple"},
+        {"type": "string", "title": "Lime", "const": "lime"},
+        {"type": "string", "title": "Orange", "const": "orange"},
+    ]
+
+
+def test_contains_only_empty_choices():
+    """Empty choices should not emit an anyOf or uniqueItems."""
+
+    class TestSchema(Schema):
+        foo = fields.List(fields.String, validate=ContainsOnly(choices=[]))
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert "anyOf" not in foo_property["items"]
+    assert "uniqueItems" not in foo_property
+
+
+def test_contains_only_on_non_array_field_is_noop():
+    """ContainsOnly on a non-array field shouldn't crash or wrap items."""
+
+    class TestSchema(Schema):
+        foo = fields.String(
+            validate=ContainsOnly(choices=["a", "b"], labels=["A", "B"])
+        )
+
+    schema = TestSchema()
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert "uniqueItems" not in foo_property
+    assert "items" not in foo_property
 
 
 def test_range():


### PR DESCRIPTION
Bundled follow-up to 0.14.0. Nine changes rebased / re-reviewed from the open-PR backlog, kept on one branch so you can review and merge as a single unit. Each commit is self-contained and credits the original contributor.

## Commits (newest first)

1. **Emit schema-level title and description from Meta** (#99, @LukeMarlin). `class Meta: title = ..., description = ...` flow through to the definition entry. Rejects non-strings with `UnsupportedValueError`.
2. **Optionally pass JSONSchema context to `_jsonschema_type_mapping`** (#165, @chenguo). If the method declares 2 extra params, we pass the JSONSchema instance and the schema `obj`. Unlocks wrapper-style custom fields that need to re-enter the dumping machinery.
3. **Honor metadata and default on custom-typed fields** (#21, @eligundry). Fields with `_jsonschema_type_mapping` previously dropped `metadata={...}` content and `dump_default`. Applied via a new `_apply_custom_field_attributes` helper.
4. **Guard `default` emission against non-serializable values** (motivated by #181, @yuval-p). `fields.UUID(dump_default=uuid.uuid4())` previously emitted a `UUID` object as `default`, breaking downstream `json.dumps`. Scoped the fix to a serializability check — did not pick up the PR's callable-invocation path (that freezes a one-shot value into the schema).
5. **Add `definitions_path` constructor argument** (#179, @mrtedn21). Targets OpenAPI's `#/components/schemas/` convention. Propagates to nested schemas.
6. **Propagate `props_ordered` to nested schemas** (#129, @sdefauw). Regression for #109 — the flag was reset to False when processing nested schemas.
7. **Add `ContainsOnly` validator handler** (#96, @Lundalogik). List field + ContainsOnly emits `items.anyOf: [{const}, ...]` + `uniqueItems`.
8. **Honor `allow_none` on Nested fields** (#122, @avilaton). Nested `allow_none=True` now emits `anyOf: [<schema>, {"type": "null"}]`. Kept the inline `$ref` shape — did not take the BC-breaking type-removal from that PR.
9. **Add jsonschema-validation regression test for Integer fields** (#118, @SteadBytes). The `int → {"type": "integer"}` fix itself already landed in 0.13.0 via #152; this adds the regression test that was bundled with the original PR.

## Backward compatibility
- All changes are additive or bug fixes. No public API removed or renamed.
- `ALLOW_ENUMS` still means "`marshmallow_enum` is importable" (unchanged since 0.14.0).
- New constructor kwargs (`definitions_path`) default to the previous hardcoded value.
- Non-serializable `default` values are now dropped from the schema instead of being emitted as Python objects — technically a change, but the old behavior produced un-serializable output.

## Issues closed by this PR
Closes #21, #96, #99, #101, #109, #117, #118, #121, #122, #129, #165, #179, #181.
Supersedes #195, #196, #197, #198, #199 (individual PRs opened during this session).

## Test plan
- [x] `pytest` — 81 passed (66 at start of session)
- [x] `mypy marshmallow_jsonschema` — clean
- [x] `black --check .` — clean
- [ ] CI matrix 3.9-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)