### PR TITLE
Honor Schema(partial=...) in get_required (#112)

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -265,15 +265,36 @@ class JSONSchema(Schema):
         return properties
 
     def get_required(self, obj) -> typing.Union[typing.List[str], typing.Any]:
-        """Fill out required field."""
+        """Fill out required field.
+
+        Honors `Schema(partial=...)`: when `partial` is `True` no fields
+        are required, when `partial` is a tuple/list the named fields are
+        treated as optional even if declared `required=True`.
+        """
         required = []
+        # `partial` is a Schema instance attribute and only meaningful on
+        # an instance, not a class. `callable(obj)` here means we were
+        # given a Schema class - treat that as no partial.
         if callable(obj):
             field_items_iterable = sorted(obj().fields.items())
+            partial = None
         else:
             field_items_iterable = sorted(obj.fields.items())
+            partial = getattr(obj, "partial", None)
+
         for field_name, field in field_items_iterable:
-            if field.required:
-                required.append(field.data_key or field.name)
+            if not field.required:
+                continue
+            # `partial=True` makes every field optional.
+            if partial is True:
+                continue
+            # `partial=(name1, name2, ...)` makes only the named fields
+            # optional. Match against `field_name` (the attribute name
+            # in the schema), which is what marshmallow's `partial`
+            # itself matches against.
+            if isinstance(partial, (list, tuple)) and field_name in partial:
+                continue
+            required.append(field.data_key or field.name)
 
         return required or missing
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -871,6 +871,48 @@ def test_required_excluded_when_empty():
     assert "required" not in dumped["definitions"]["TestSchema"]
 
 
+def test_partial_true_drops_required():
+    """`Schema(partial=True)` makes every field optional. The dumped
+    JSON Schema should not include any of them in `required`.
+    Regression for #112."""
+
+    class TestSchema(Schema):
+        name = fields.String(required=True)
+        email = fields.String(required=True)
+
+    dumped = validate_and_dump(TestSchema(partial=True))
+    assert "required" not in dumped["definitions"]["TestSchema"]
+
+
+def test_partial_tuple_drops_named_fields_from_required():
+    """`Schema(partial=("foo",))` makes only the named fields optional.
+    Other required fields should still appear in `required`.
+    Regression for #112."""
+
+    class TestSchema(Schema):
+        name = fields.String(required=True)
+        email = fields.String(required=True)
+        age = fields.Integer(required=True)
+
+    dumped = validate_and_dump(TestSchema(partial=("email", "age")))
+    assert dumped["definitions"]["TestSchema"]["required"] == ["name"]
+
+
+def test_partial_does_not_affect_non_partial_dump():
+    """Sanity: with no `partial` argument the existing behavior
+    (all `required=True` fields appear) must be preserved."""
+
+    class TestSchema(Schema):
+        name = fields.String(required=True)
+        email = fields.String(required=True)
+
+    dumped = validate_and_dump(TestSchema())
+    assert sorted(dumped["definitions"]["TestSchema"]["required"]) == [
+        "email",
+        "name",
+    ]
+
+
 def test_required_uses_data_key():
     class TestSchema(Schema):
         optional_value = fields.String(data_key="opt", required=True)


### PR DESCRIPTION
Closes #112.

## The bug
Marshmallow's `Schema(partial=True)` and `Schema(partial=("name1", "name2"))` make all (or some) fields optional at load time, but `JSONSchema.get_required` was ignoring the flag and always emitting every `required=True` field. Reproducer:

```python
class UserSchema(Schema):
    name = fields.String(required=True)
    email = fields.String(required=True)

JSONSchema().dump(UserSchema(partial=True))
# definitions.UserSchema.required: ["email", "name"]   ← wrong
```

## The fix
Read `obj.partial` and skip required fields accordingly. Guarded for the rare case where `get_properties`/`get_required` is invoked with a Schema class (rather than instance) - `partial` is an instance attribute only.

After:
- `partial=True` → no `required` key
- `partial=("email",)` → only the other required fields stay
- no `partial` argument → existing behavior unchanged

## Test plan
- [x] 3 new tests cover partial=True, partial=tuple, baseline
- [x] m3: 125 passed
- [x] m4: 124 passed + 1 skipped
- [x] mypy / black clean
- [ ] CI matrix (5 Pythons × 2 marshmallow majors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)