### PR TITLE
Improve UnsupportedValueError message for unmappable custom fields (#157)

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -468,7 +468,15 @@ class JSONSchema(Schema):
             if issubclass(field.__class__, map_class):
                 return pytype
 
-        raise UnsupportedValueError("unsupported field type %s" % field)
+        raise UnsupportedValueError(
+            "Cannot derive a JSON Schema type for field "
+            "%s (class %s). To support a custom field, either "
+            "subclass an existing marshmallow field type "
+            "(e.g. `class MyField(fields.String): ...`) or add a "
+            "`_jsonschema_type_mapping(self)` method to the field "
+            'returning a JSON Schema dict like `{"type": "string"}`.'
+            % (getattr(field, "name", "<unnamed>"), type(field).__name__)
+        )
 
     def _call_jsonschema_type_mapping(self, obj, field):
         """Invoke the field's ``_jsonschema_type_mapping``, optionally passing

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -766,6 +766,29 @@ def test_field_subclass():
         _ = validate_and_dump(schema)
 
 
+def test_unsupported_field_error_points_at_fix():
+    """The error raised for an unmappable custom field should tell the
+    user how to fix it: subclass an existing field type, or add
+    `_jsonschema_type_mapping`. Regression for #157."""
+
+    class PinCode(fields.Field):
+        pass
+
+    class TestSchema(Schema):
+        pin_code = PinCode()
+
+    with pytest.raises(UnsupportedValueError) as exc:
+        JSONSchema().dump(TestSchema())
+
+    msg = str(exc.value)
+    # Names the offending field and class so users can locate it quickly.
+    assert "pin_code" in msg
+    assert "PinCode" in msg
+    # Names both supported workarounds.
+    assert "_jsonschema_type_mapping" in msg
+    assert "subclass" in msg.lower()
+
+
 def test_readonly():
     class TestSchema(Schema):
         id = fields.Integer(required=True)


### PR DESCRIPTION
Closes #157.

When a user defines a custom field by subclassing `fields.Field` (the base class) without adding `_jsonschema_type_mapping`, dumping the schema raises `UnsupportedValueError`. The previous message just dumped the field's repr, which left the user with no clue how to fix it.

## Before
```
unsupported field type <fields.PinCode(dump_default=<marshmallow.missing>, attribute=None, validate=None, required=False, ...)>
```

## After
```
Cannot derive a JSON Schema type for field pin_code (class PinCode). To support a custom field, either subclass an existing marshmallow field type (e.g. `class MyField(fields.String): ...`) or add a `_jsonschema_type_mapping(self)` method to the field returning a JSON Schema dict like `{"type": "string"}`.
```

Names the offending field, names its class, and points at both supported workarounds.

## Test plan
- [x] New `test_unsupported_field_error_points_at_fix` asserts the message names the field, class, and both workarounds
- [x] m3: 123 passed
- [x] m4: 122 passed + 1 skipped
- [x] mypy / black clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)