### PR TITLE
Top-level array schemas (#92) + by-value enums for string Enums (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ Yields:
 `fields.Nested("Self")` and `fields.Nested(lambda: SomeSchema())` are
 both supported for recursive references.
 
+### Top-level array (`many=True`)
+
+Passing `many=True` to a schema describes a list of objects rather
+than a single one; the dumped JSON Schema reflects that with an array
+envelope:
+
+```python
+JSONSchema().dump(UserSchema(many=True))
+```
+
+Yields:
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {"UserSchema": { ... }},
+    "type": "array",
+    "items": {"$ref": "#/definitions/UserSchema"}
+}
+```
+
 ### Flask + JSON Schema form rendering
 
 A complete runnable Flask example lives at
@@ -174,6 +195,24 @@ out of the box and emits the enum-member names. The third-party
 [marshmallow-enum](https://pypi.org/project/marshmallow-enum/)
 `EnumField` is also supported when installed; native Enum is preferred
 when both are present.
+
+`by_value=True` enums are supported when every member's value is a
+string — the common pattern for serialising enums as their string
+value in the wire format:
+
+```python
+class Status(str, Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+class S(Schema):
+    status = fields.Enum(Status, by_value=True)
+# {"status": {"enum": ["active", "inactive"], "type": "string"}}
+```
+
+Mixed-type or non-string enum values still raise
+`NotImplementedError` — use the `class MyEnum(str, Enum)` pattern, or
+load by name instead.
 
 ## Advanced usage
 

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -146,6 +146,27 @@ FIELD_VALIDATORS = {
 }
 
 
+def _by_value_enum_strings(enum_cls) -> typing.List[str]:
+    """Return the string values of an enum for use as JSON Schema `enum`
+    when the field is configured to serialize by value.
+
+    Restricted to string-valued enums (the common
+    `class MyEnum(str, Enum): X = "x"` pattern). Mixed or non-string
+    values raise `NotImplementedError` because emitting them would
+    contradict our default `type: "string"` mapping for enum fields.
+    Closes #156.
+    """
+    values = [member.value for member in enum_cls]
+    if not all(isinstance(v, str) for v in values):
+        raise NotImplementedError(
+            "JSON Schema for by-value enums currently requires all values to "
+            "be strings; got types %s. Use a `class MyEnum(str, Enum)` "
+            "pattern, or load by name instead."
+            % sorted({type(v).__name__ for v in values})
+        )
+    return values
+
+
 def _is_json_serializable(value) -> bool:
     """Return True if `value` can be emitted into a JSON schema directly.
 
@@ -345,11 +366,7 @@ class JSONSchema(Schema):
         assert ALLOW_MARSHMALLOW_ENUM and isinstance(field, EnumField)
 
         if field.load_by == LoadDumpOptions.value:
-            # Python allows enum values to be almost anything, so it's easier to just load from the
-            # names of the enum's which will have to be strings.
-            raise NotImplementedError(
-                "Currently do not support JSON schema for enums loaded by value"
-            )
+            return _by_value_enum_strings(field.enum)
 
         return [value.name for value in field.enum]
 
@@ -357,11 +374,7 @@ class JSONSchema(Schema):
         assert ALLOW_NATIVE_ENUM and isinstance(field, NativeEnumField)
 
         if field.by_value:
-            # Python allows enum values to be almost anything, so it's easier to just load from the
-            # names of the enum's which will have to be strings.
-            raise NotImplementedError(
-                "Currently do not support JSON schema for enums loaded by value"
-            )
+            return _by_value_enum_strings(field.enum)
 
         return [value.name for value in field.enum]
 
@@ -691,9 +704,19 @@ class JSONSchema(Schema):
                 data[meta_key] = value
 
         self._nested_schema_classes[name] = data
-        root = {
+        ref = "#/{path}/{name}".format(path=self.definitions_path, name=name)
+        # `Schema(many=True)` describes a list of objects rather than a
+        # single one; emit Draft-7's array envelope so consumers don't
+        # have to post-process the output. Closes #92.
+        if getattr(self.obj, "many", False):
+            return {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                self.definitions_path: self._nested_schema_classes,
+                "type": "array",
+                "items": {"$ref": ref},
+            }
+        return {
             "$schema": "http://json-schema.org/draft-07/schema#",
             self.definitions_path: self._nested_schema_classes,
-            "$ref": "#/{path}/{name}".format(path=self.definitions_path, name=name),
+            "$ref": ref,
         }
-        return root

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -766,6 +766,89 @@ def test_field_subclass():
         _ = validate_and_dump(schema)
 
 
+def test_dump_many_emits_top_level_array():
+    """`Schema(many=True)` should produce a top-level array envelope
+    rather than the single-object `$ref` form. Closes #92."""
+
+    class UserSchema(Schema):
+        name = fields.String()
+        age = fields.Integer()
+
+    dumped = JSONSchema().dump(UserSchema(many=True))
+    assert dumped["type"] == "array"
+    assert dumped["items"] == {"$ref": "#/definitions/UserSchema"}
+    # The single-object `$ref` should NOT be at the root any more.
+    assert "$ref" not in dumped
+    # The definition itself is unchanged.
+    assert "UserSchema" in dumped["definitions"]
+
+
+def test_dump_single_unchanged_by_many_change():
+    """Sanity: `Schema()` (single) keeps the existing root shape with
+    `$ref` and no `type: array`."""
+
+    class UserSchema(Schema):
+        name = fields.String()
+
+    dumped = JSONSchema().dump(UserSchema())
+    assert dumped["$ref"] == "#/definitions/UserSchema"
+    assert "type" not in dumped
+    assert "items" not in dumped
+
+
+@pytest.mark.skipif(
+    not ALLOW_NATIVE_ENUM, reason="requires marshmallow>=3.18 for native Enum field"
+)
+def test_native_enum_by_value_strings():
+    """`fields.Enum(MyEnum, by_value=True)` where MyEnum's values are
+    strings should emit those values in the `enum` list. Closes #156."""
+
+    class Status(str, Enum):
+        ACTIVE = "active"
+        INACTIVE = "inactive"
+
+    class S(Schema):
+        status = NativeEnumField(Status, by_value=True)
+
+    prop = validate_and_dump(S())["definitions"]["S"]["properties"]["status"]
+    assert sorted(prop["enum"]) == ["active", "inactive"]
+    assert prop["type"] == "string"
+
+
+@pytest.mark.skipif(
+    not ALLOW_NATIVE_ENUM, reason="requires marshmallow>=3.18 for native Enum field"
+)
+def test_native_enum_by_value_non_strings_raises():
+    """A by-value enum whose values aren't all strings should raise
+    `NotImplementedError` with a clear pointer at the `(str, Enum)`
+    workaround."""
+
+    class NumStatus(Enum):
+        ONE = 1
+        TWO = 2
+
+    class S(Schema):
+        n = NativeEnumField(NumStatus, by_value=True)
+
+    with pytest.raises(NotImplementedError) as exc:
+        JSONSchema().dump(S())
+    assert "str" in str(exc.value)
+
+
+def test_marshmallow_enum_by_value_strings():
+    """Same loosening for the third-party `marshmallow_enum.EnumField`."""
+
+    class Status(str, Enum):
+        ACTIVE = "active"
+        INACTIVE = "inactive"
+
+    class S(Schema):
+        status = EnumField(Status, by_value=True)
+
+    prop = validate_and_dump(S())["definitions"]["S"]["properties"]["status"]
+    assert sorted(prop["enum"]) == ["active", "inactive"]
+
+
 def test_unsupported_field_error_points_at_fix():
     """The error raised for an unmappable custom field should tell the
     user how to fix it: subclass an existing field type, or add


### PR DESCRIPTION
Two narrow features from the open-issue backlog. Both additive, low BC risk.

## Closes #92 — top-level array schemas

`JSONSchema().dump(MySchema(many=True))` previously ignored `many` and emitted the same single-object envelope, leaving callers to post-process. Now emits the JSON Schema array form:

```json
{
  "\$schema": "...",
  "definitions": {"UserSchema": {...}},
  "type": "array",
  "items": {"\$ref": "#/definitions/UserSchema"}
}
```

Single-object schemas keep the existing `\$ref` envelope unchanged.

## Closes #156 — by-value enums for string Enums

`fields.Enum(MyEnum, by_value=True)` (native + third-party `marshmallow_enum`) previously raised `NotImplementedError`. Now supported when all enum values are strings (the common `class MyEnum(str, Enum): X = "x"` pattern):

```python
class Status(str, Enum):
    ACTIVE = "active"
    INACTIVE = "inactive"

class S(Schema):
    status = fields.Enum(Status, by_value=True)
# {"status": {"enum": ["active", "inactive"], "type": "string"}}
```

Mixed or non-string values still raise, but with a clearer message pointing at the `(str, Enum)` workaround.

## Test plan
- [x] m3: 131 passed
- [x] m4: 130 + 1 skipped
- [x] mypy / black clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)