### PR TITLE
Support marshmallow_oneofschema.OneOfSchema (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,56 @@ machinery (e.g. to emit a `$ref` to a recursive schema), declare
 `_jsonschema_type_mapping(self, json_schema, obj)` with the two extra
 parameters and the `JSONSchema` instance + obj will be passed in.
 
+### Polymorphic schemas (`marshmallow-oneofschema`)
+
+When the optional [`marshmallow-oneofschema`](https://github.com/marshmallow-code/marshmallow-oneofschema)
+package is installed, dumping a `OneOfSchema` produces a JSON Schema
+`oneOf` over each variant — with the discriminator field pinned to its
+constant value:
+
+```python
+from marshmallow import Schema, fields
+from marshmallow_oneofschema import OneOfSchema
+from marshmallow_jsonschema import JSONSchema
+
+class TriangleSchema(Schema):
+    base = fields.Float(required=True)
+    height = fields.Float(required=True)
+
+class CircleSchema(Schema):
+    radius = fields.Float(required=True)
+
+class ShapeSchema(OneOfSchema):
+    type_schemas = {"triangle": TriangleSchema, "circle": CircleSchema}
+
+JSONSchema().dump(ShapeSchema())
+```
+
+Yields (abbreviated):
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "base": {"type": "number", "...": "..."},
+        "height": {"type": "number", "...": "..."},
+        "type": {"const": "triangle", "type": "string"}
+      },
+      "required": ["base", "height", "type"]
+    },
+    { "...circle variant...": "..." }
+  ]
+}
+```
+
+Variants are inlined (not `$ref`) so the schema actually validates the
+wire format `OneOfSchema` produces. Custom `type_field` (default
+`"type"`) is honored. Install with `pip install marshmallow-jsonschema[oneofschema]`.
+
 ### React-JSONSchema-Form Extension
 
 [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/)

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -636,7 +636,7 @@ class JSONSchema(Schema):
         # `oneOf` over the variants instead. The many / allow_none /
         # metadata wrap below still applies to the resulting schema.
         if ALLOW_ONEOFSCHEMA and isinstance(nested_instance, OneOfSchema):
-            schema = {"oneOf": self._register_oneof_variants(nested_instance)}
+            schema = {"oneOf": self._build_oneof_variants(nested_instance)}
         else:
             outer_name = obj.__class__.__name__
             # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
@@ -695,45 +695,57 @@ class JSONSchema(Schema):
             "$ref": "#/{}/{}".format(self.definitions_path, name),
         }
 
-    def _register_oneof_variants(self, oneof_obj):
-        """Register each variant schema of a `OneOfSchema` instance as a
-        definition and return a list of `{"$ref": ...}` items suitable
-        for `oneOf`.
+    def _build_oneof_variants(self, oneof_obj):
+        """Build a self-contained schema for each variant of a
+        `OneOfSchema` and return a list suitable for `oneOf`.
 
-        Each variant gets its own definition under its own class name -
-        we don't try to encode the discriminator field as a `const` here
-        because each variant schema is meant to be reusable on its own,
-        and pinning the discriminator into the definition would pollute
-        it for the standalone case.
+        Each returned schema is inlined (not a `$ref`) so it can carry
+        the discriminator field as a `const`. This is what makes the
+        emitted `oneOf` actually validate the wire format that
+        `OneOfSchema` produces - by default `OneOfSchema` strips the
+        discriminator from the variant's own field set and re-injects
+        it at dump time, so a bare `$ref` to the variant's standalone
+        definition would reject the discriminator key under
+        `additionalProperties: false`.
+
+        Any nested-schema definitions discovered while dumping a
+        variant are still propagated into the outer document, so
+        `$ref`s inside the inlined variant resolve correctly.
         """
+        type_field = oneof_obj.type_field
         variants = []
         for type_value, schema_cls in oneof_obj.type_schemas.items():
-            name = schema_cls.__name__
-            if name not in self._nested_schema_classes:
-                wrapped_nested = self.__class__(
-                    nested=True,
-                    props_ordered=self.props_ordered,
-                    definitions_path=self.definitions_path,
-                )
-                wrapped_dumped = wrapped_nested.dump(schema_cls())
-                wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
-                    schema_cls
-                )
-                for meta_key in ("title", "description"):
-                    value = _resolve_schema_meta_string(schema_cls, meta_key)
-                    if value is not None:
-                        wrapped_dumped[meta_key] = value
-                self._nested_schema_classes[name] = wrapped_dumped
-                self._nested_schema_classes.update(
-                    wrapped_nested._nested_schema_classes
-                )
-            variants.append(
-                {
-                    "$ref": "#/{path}/{name}".format(
-                        path=self.definitions_path, name=name
-                    )
-                }
+            wrapped_nested = self.__class__(
+                nested=True,
+                props_ordered=self.props_ordered,
+                definitions_path=self.definitions_path,
             )
+            variant_schema = wrapped_nested.dump(schema_cls())
+            variant_schema["additionalProperties"] = _resolve_additional_properties(
+                schema_cls
+            )
+            for meta_key in ("title", "description"):
+                value = _resolve_schema_meta_string(schema_cls, meta_key)
+                if value is not None:
+                    variant_schema[meta_key] = value
+
+            # Inject the discriminator field as a const-valued property
+            # and add it to required so consumers can rely on it.
+            variant_schema.setdefault("properties", {})
+            variant_schema["properties"][type_field] = {
+                "type": "string",
+                "const": type_value,
+                "title": type_field,
+            }
+            existing_required = list(variant_schema.get("required", []))
+            if type_field not in existing_required:
+                variant_schema["required"] = sorted(existing_required + [type_field])
+
+            # Carry through any nested definitions discovered inside
+            # the variant - the inlined variant may still reference
+            # them via `$ref`.
+            self._nested_schema_classes.update(wrapped_nested._nested_schema_classes)
+            variants.append(variant_schema)
         return variants
 
     def dump(self, obj, **kwargs) -> typing.Dict[str, typing.Any]:
@@ -753,7 +765,7 @@ class JSONSchema(Schema):
         """Top-level dump for a `OneOfSchema` instance. Emits a `oneOf`
         envelope referencing each registered variant. Honors `many=True`
         by wrapping in an array."""
-        variants = self._register_oneof_variants(obj)
+        variants = self._build_oneof_variants(obj)
         body = {"oneOf": variants}
         if self.nested:
             return body

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -636,7 +636,7 @@ class JSONSchema(Schema):
         # `oneOf` over the variants instead. The many / allow_none /
         # metadata wrap below still applies to the resulting schema.
         if ALLOW_ONEOFSCHEMA and isinstance(nested_instance, OneOfSchema):
-            schema = {"oneOf": self._build_oneof_variants(nested_instance)}
+            schema = self._oneof_body(nested_instance)
         else:
             outer_name = obj.__class__.__name__
             # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
@@ -784,16 +784,23 @@ class JSONSchema(Schema):
             return self._dump_oneof_root(obj)
         return super().dump(obj, **kwargs)
 
-    def _dump_oneof_root(self, obj) -> typing.Dict[str, typing.Any]:
-        """Top-level dump for a `OneOfSchema` instance. Emits a `oneOf`
-        envelope referencing each registered variant. Honors `many=True`
-        by wrapping in an array."""
-        variants = self._build_oneof_variants(obj)
-        body: typing.Dict[str, typing.Any] = {"oneOf": variants}
+    def _oneof_body(self, obj) -> typing.Dict[str, typing.Any]:
+        """The `oneOf` envelope dict for a `OneOfSchema` instance,
+        including the schema-level `Meta.title` / `Meta.description` if
+        set. Used both for top-level dumps and for nested-field dumps so
+        Meta surfaces consistently in both positions."""
+        body: typing.Dict[str, typing.Any] = {"oneOf": self._build_oneof_variants(obj)}
         for meta_key in ("title", "description"):
             value = _resolve_schema_meta_string(obj.__class__, meta_key)
             if value is not None:
                 body[meta_key] = value
+        return body
+
+    def _dump_oneof_root(self, obj) -> typing.Dict[str, typing.Any]:
+        """Top-level dump for a `OneOfSchema` instance. Emits a `oneOf`
+        envelope referencing each registered variant. Honors `many=True`
+        by wrapping in an array."""
+        body = self._oneof_body(obj)
         if self.nested:
             return body
         root: typing.Dict[str, typing.Any] = {

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -732,6 +732,20 @@ class JSONSchema(Schema):
             # Inject the discriminator field as a const-valued property
             # and add it to required so consumers can rely on it.
             variant_schema.setdefault("properties", {})
+            if type_field in variant_schema["properties"]:
+                # The variant declares its own field with the same name as
+                # the OneOfSchema discriminator. Silently overwriting would
+                # mask a real schema mismatch (the variant's declared type
+                # might not even be a string), so refuse and force the user
+                # to rename one or the other.
+                raise UnsupportedValueError(
+                    "OneOfSchema variant {!r} (type_value={!r}) declares a "
+                    "field named {!r}, which collides with the OneOfSchema "
+                    "discriminator. Rename the field or change "
+                    "`type_field` on the OneOfSchema.".format(
+                        schema_cls.__name__, type_value, type_field
+                    )
+                )
             variant_schema["properties"][type_field] = {
                 "type": "string",
                 "const": type_value,

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -721,6 +721,29 @@ class JSONSchema(Schema):
                 "`oneOf` with zero variants. Add at least one entry to "
                 "`type_schemas`.".format(oneof_obj.__class__.__name__)
             )
+        oneof_cls_name = oneof_obj.__class__.__name__
+        in_progress = getattr(self, "_oneof_in_progress", None)
+        if in_progress is None:
+            in_progress = set()
+            self._oneof_in_progress = in_progress
+        if oneof_cls_name in in_progress:
+            # A variant transitively references its own OneOfSchema.
+            # Variants are inlined (no shared definition to $ref back
+            # to), so the natural code path would recurse forever.
+            # Raise a clear error instead of stack-overflowing.
+            raise UnsupportedValueError(
+                "Recursive OneOfSchema {!r} is not supported: a variant "
+                "references the same OneOfSchema, and variants are inlined "
+                "rather than registered as a definition that can be "
+                "$ref'd back to.".format(oneof_cls_name)
+            )
+        in_progress.add(oneof_cls_name)
+        try:
+            return self._build_oneof_variants_unguarded(oneof_obj, in_progress)
+        finally:
+            in_progress.discard(oneof_cls_name)
+
+    def _build_oneof_variants_unguarded(self, oneof_obj, in_progress):
         type_field = oneof_obj.type_field
         variants = []
         for type_value, schema_cls in oneof_obj.type_schemas.items():
@@ -729,6 +752,9 @@ class JSONSchema(Schema):
                 props_ordered=self.props_ordered,
                 definitions_path=self.definitions_path,
             )
+            # Share the recursion guard set so re-entry is detected
+            # across the wrapped instance's own dump pipeline.
+            wrapped_nested._oneof_in_progress = in_progress
             variant_schema = wrapped_nested.dump(schema_cls())
             variant_schema["additionalProperties"] = _resolve_additional_properties(
                 schema_cls

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -712,6 +712,15 @@ class JSONSchema(Schema):
         variant are still propagated into the outer document, so
         `$ref`s inside the inlined variant resolve correctly.
         """
+        if not oneof_obj.type_schemas:
+            # `oneOf: []` is invalid per Draft-07 (must have >=1 element).
+            # An empty `type_schemas` is almost certainly a misconfiguration
+            # rather than an intentional "match nothing" schema.
+            raise UnsupportedValueError(
+                "OneOfSchema {!r} has empty `type_schemas`; cannot emit "
+                "`oneOf` with zero variants. Add at least one entry to "
+                "`type_schemas`.".format(oneof_obj.__class__.__name__)
+            )
         type_field = oneof_obj.type_field
         variants = []
         for type_value, schema_cls in oneof_obj.type_schemas.items():
@@ -780,10 +789,14 @@ class JSONSchema(Schema):
         envelope referencing each registered variant. Honors `many=True`
         by wrapping in an array."""
         variants = self._build_oneof_variants(obj)
-        body = {"oneOf": variants}
+        body: typing.Dict[str, typing.Any] = {"oneOf": variants}
+        for meta_key in ("title", "description"):
+            value = _resolve_schema_meta_string(obj.__class__, meta_key)
+            if value is not None:
+                body[meta_key] = value
         if self.nested:
             return body
-        root = {
+        root: typing.Dict[str, typing.Any] = {
             "$schema": "http://json-schema.org/draft-07/schema#",
             self.definitions_path: self._nested_schema_classes,
         }

--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -56,6 +56,14 @@ try:
 except ImportError:
     ALLOW_NATIVE_ENUM = False
 
+ALLOW_ONEOFSCHEMA: bool
+try:
+    from marshmallow_oneofschema import OneOfSchema
+
+    ALLOW_ONEOFSCHEMA = True
+except ImportError:
+    ALLOW_ONEOFSCHEMA = False
+
 # Backward-compat alias: historically this meant "marshmallow_enum is
 # importable", and external code has checked it as such. Keep it pointed
 # at the third-party flag so the semantic doesn't shift under callers.
@@ -622,31 +630,41 @@ class JSONSchema(Schema):
             name = nested_cls.__name__
             nested_instance = nested
 
-        outer_name = obj.__class__.__name__
-        # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
-        # put it in our list of schema defs
-        if name not in self._nested_schema_classes and name != outer_name:
-            wrapped_nested = self.__class__(
-                nested=True,
-                props_ordered=self.props_ordered,
-                definitions_path=self.definitions_path,
-            )
-            wrapped_dumped = wrapped_nested.dump(nested_instance)
+        # `marshmallow_oneofschema.OneOfSchema` dispatches to one of N
+        # variant schemas at runtime, so a single $ref to the OneOf
+        # class itself wouldn't describe any actual instance. Emit
+        # `oneOf` over the variants instead. The many / allow_none /
+        # metadata wrap below still applies to the resulting schema.
+        if ALLOW_ONEOFSCHEMA and isinstance(nested_instance, OneOfSchema):
+            schema = {"oneOf": self._register_oneof_variants(nested_instance)}
+        else:
+            outer_name = obj.__class__.__name__
+            # If this is not a schema we've seen, and it's not this schema (checking this for recursive schemas),
+            # put it in our list of schema defs
+            if name not in self._nested_schema_classes and name != outer_name:
+                wrapped_nested = self.__class__(
+                    nested=True,
+                    props_ordered=self.props_ordered,
+                    definitions_path=self.definitions_path,
+                )
+                wrapped_dumped = wrapped_nested.dump(nested_instance)
 
-            wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
-                nested_cls
-            )
-            for meta_key in ("title", "description"):
-                value = _resolve_schema_meta_string(nested_cls, meta_key)
-                if value is not None:
-                    wrapped_dumped[meta_key] = value
+                wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
+                    nested_cls
+                )
+                for meta_key in ("title", "description"):
+                    value = _resolve_schema_meta_string(nested_cls, meta_key)
+                    if value is not None:
+                        wrapped_dumped[meta_key] = value
 
-            self._nested_schema_classes[name] = wrapped_dumped
+                self._nested_schema_classes[name] = wrapped_dumped
 
-            self._nested_schema_classes.update(wrapped_nested._nested_schema_classes)
+                self._nested_schema_classes.update(
+                    wrapped_nested._nested_schema_classes
+                )
 
-        # and the schema is just a reference to the def
-        schema = self._schema_base(name)
+            # and the schema is just a reference to the def
+            schema = self._schema_base(name)
 
         # NOTE: doubled up to maintain backwards compatibility
         metadata = field.metadata.get("metadata", {})
@@ -677,6 +695,47 @@ class JSONSchema(Schema):
             "$ref": "#/{}/{}".format(self.definitions_path, name),
         }
 
+    def _register_oneof_variants(self, oneof_obj):
+        """Register each variant schema of a `OneOfSchema` instance as a
+        definition and return a list of `{"$ref": ...}` items suitable
+        for `oneOf`.
+
+        Each variant gets its own definition under its own class name -
+        we don't try to encode the discriminator field as a `const` here
+        because each variant schema is meant to be reusable on its own,
+        and pinning the discriminator into the definition would pollute
+        it for the standalone case.
+        """
+        variants = []
+        for type_value, schema_cls in oneof_obj.type_schemas.items():
+            name = schema_cls.__name__
+            if name not in self._nested_schema_classes:
+                wrapped_nested = self.__class__(
+                    nested=True,
+                    props_ordered=self.props_ordered,
+                    definitions_path=self.definitions_path,
+                )
+                wrapped_dumped = wrapped_nested.dump(schema_cls())
+                wrapped_dumped["additionalProperties"] = _resolve_additional_properties(
+                    schema_cls
+                )
+                for meta_key in ("title", "description"):
+                    value = _resolve_schema_meta_string(schema_cls, meta_key)
+                    if value is not None:
+                        wrapped_dumped[meta_key] = value
+                self._nested_schema_classes[name] = wrapped_dumped
+                self._nested_schema_classes.update(
+                    wrapped_nested._nested_schema_classes
+                )
+            variants.append(
+                {
+                    "$ref": "#/{path}/{name}".format(
+                        path=self.definitions_path, name=name
+                    )
+                }
+            )
+        return variants
+
     def dump(self, obj, **kwargs) -> typing.Dict[str, typing.Any]:
         """Render `obj` as a JSON Schema dict.
 
@@ -686,7 +745,28 @@ class JSONSchema(Schema):
         `$ref`).
         """
         self.obj = obj
+        if ALLOW_ONEOFSCHEMA and isinstance(obj, OneOfSchema):
+            return self._dump_oneof_root(obj)
         return super().dump(obj, **kwargs)
+
+    def _dump_oneof_root(self, obj) -> typing.Dict[str, typing.Any]:
+        """Top-level dump for a `OneOfSchema` instance. Emits a `oneOf`
+        envelope referencing each registered variant. Honors `many=True`
+        by wrapping in an array."""
+        variants = self._register_oneof_variants(obj)
+        body = {"oneOf": variants}
+        if self.nested:
+            return body
+        root = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            self.definitions_path: self._nested_schema_classes,
+        }
+        if getattr(obj, "many", False):
+            root["type"] = "array"
+            root["items"] = body
+        else:
+            root.update(body)
+        return root
 
     @post_dump
     def wrap(self, data, **_) -> typing.Dict[str, typing.Any]:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest-cov
 # Optional installs for the wheel, but always required for tests
 marshmallow-enum
 marshmallow-union
+marshmallow-oneofschema
 mypy>=1.1.1
 
 pre-commit~=2.15

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIREMENTS_TESTS = open(
 EXTRAS_REQUIRE = {
     "enum": ["marshmallow-enum"],
     "union": ["marshmallow-union"],
+    "oneofschema": ["marshmallow-oneofschema"],
 }
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -898,6 +898,9 @@ def test_oneofschema_generated_schema_validates_wire_output():
 
     schema = JSONSchema().dump(ShapeSchema())
 
+    # The generated schema must itself be a valid Draft-7 schema.
+    jsonschema_lib.Draft7Validator.check_schema(schema)
+
     # Valid wire formats pass.
     jsonschema_lib.validate({"type": "triangle", "base": 3.0, "height": 4.0}, schema)
     jsonschema_lib.validate({"type": "circle", "radius": 5.0}, schema)
@@ -1070,6 +1073,25 @@ def test_oneofschema_meta_title_and_description_propagate():
     field_schema = nested_dumped["definitions"]["Container"]["properties"]["thing"]
     assert field_schema["title"] == "Polymorphic Thing"
     assert field_schema["description"] == "Either an A or something else later."
+
+
+def test_oneofschema_recursive_raises_clear_error():
+    """A OneOfSchema whose variant transitively references the same
+    OneOfSchema would naturally recurse forever (variants are inlined,
+    not registered as a $ref-able definition). Raise a clear error
+    instead of stack-overflowing."""
+    from marshmallow_oneofschema import OneOfSchema
+    from marshmallow_jsonschema.exceptions import UnsupportedValueError
+
+    class Node(Schema):
+        name = fields.String()
+        children = fields.List(fields.Nested(lambda: Tree()))
+
+    class Tree(OneOfSchema):
+        type_schemas = {"node": Node}
+
+    with pytest.raises(UnsupportedValueError, match="Recursive OneOfSchema"):
+        JSONSchema().dump(Tree())
 
 
 def test_oneofschema_variant_field_collides_with_discriminator_raises():

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1042,7 +1042,8 @@ def test_oneofschema_empty_type_schemas_raises():
 def test_oneofschema_meta_title_and_description_propagate():
     """`Meta.title` / `Meta.description` on the OneOfSchema itself should
     appear alongside the `oneOf` envelope, mirroring how they propagate
-    for regular schemas."""
+    for regular schemas. Holds at the document root AND when used as a
+    nested field."""
     from marshmallow_oneofschema import OneOfSchema
 
     class A(Schema):
@@ -1055,9 +1056,20 @@ def test_oneofschema_meta_title_and_description_propagate():
             title = "Polymorphic Thing"
             description = "Either an A or something else later."
 
+    # Top-level dump.
     dumped = JSONSchema().dump(S())
     assert dumped["title"] == "Polymorphic Thing"
     assert dumped["description"] == "Either an A or something else later."
+
+    # Nested-field dump - same Meta should surface at the field site
+    # since the OneOfSchema is inlined there (no separate definition).
+    class Container(Schema):
+        thing = fields.Nested(S)
+
+    nested_dumped = JSONSchema().dump(Container())
+    field_schema = nested_dumped["definitions"]["Container"]["properties"]["thing"]
+    assert field_schema["title"] == "Polymorphic Thing"
+    assert field_schema["description"] == "Either an A or something else later."
 
 
 def test_oneofschema_variant_field_collides_with_discriminator_raises():

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -851,8 +851,8 @@ def test_marshmallow_enum_by_value_strings():
 
 def test_oneofschema_top_level_emits_oneof():
     """`JSONSchema().dump(SomeOneOfSchema())` should emit a top-level
-    `oneOf` over the variant schemas instead of a useless empty
-    definition. Closes #141."""
+    `oneOf` with each variant inlined and its discriminator pinned via
+    `const`. Closes #141."""
     from marshmallow_oneofschema import OneOfSchema
 
     class TriangleSchema(Schema):
@@ -865,13 +865,56 @@ def test_oneofschema_top_level_emits_oneof():
         type_schemas = {"triangle": TriangleSchema, "circle": CircleSchema}
 
     dumped = JSONSchema().dump(ShapeSchema())
-    refs = sorted(item["$ref"] for item in dumped["oneOf"])
-    assert refs == ["#/definitions/CircleSchema", "#/definitions/TriangleSchema"]
-    # Each variant is fully described under definitions.
-    assert sorted(dumped["definitions"]) == ["CircleSchema", "TriangleSchema"]
-    assert dumped["definitions"]["TriangleSchema"]["properties"]["base"]["type"] == (
-        "number"
-    )
+
+    assert len(dumped["oneOf"]) == 2
+    by_const = {
+        variant["properties"]["type"]["const"]: variant for variant in dumped["oneOf"]
+    }
+    assert set(by_const) == {"triangle", "circle"}
+    # Each variant includes both the discriminator and its real fields.
+    assert set(by_const["triangle"]["properties"]) == {"type", "base"}
+    assert set(by_const["circle"]["properties"]) == {"type", "radius"}
+    # Discriminator is required so consumers can rely on it.
+    assert "type" in by_const["triangle"]["required"]
+
+
+def test_oneofschema_generated_schema_validates_wire_output():
+    """The generated `oneOf` schema must accept the wire format that
+    `OneOfSchema` produces (type + variant fields) and reject wrong
+    or missing discriminators. Regression guard for the validation gap
+    that motivated the design change."""
+    import jsonschema as jsonschema_lib
+    from marshmallow_oneofschema import OneOfSchema
+
+    class TriangleSchema(Schema):
+        base = fields.Float(required=True)
+        height = fields.Float(required=True)
+
+    class CircleSchema(Schema):
+        radius = fields.Float(required=True)
+
+    class ShapeSchema(OneOfSchema):
+        type_schemas = {"triangle": TriangleSchema, "circle": CircleSchema}
+
+    schema = JSONSchema().dump(ShapeSchema())
+
+    # Valid wire formats pass.
+    jsonschema_lib.validate({"type": "triangle", "base": 3.0, "height": 4.0}, schema)
+    jsonschema_lib.validate({"type": "circle", "radius": 5.0}, schema)
+
+    # Unknown discriminator rejected.
+    with pytest.raises(jsonschema_lib.ValidationError):
+        jsonschema_lib.validate({"type": "square", "side": 5.0}, schema)
+
+    # Missing discriminator rejected.
+    with pytest.raises(jsonschema_lib.ValidationError):
+        jsonschema_lib.validate({"base": 3.0, "height": 4.0}, schema)
+
+    # Extra field rejected (additionalProperties: false on each variant).
+    with pytest.raises(jsonschema_lib.ValidationError):
+        jsonschema_lib.validate(
+            {"type": "triangle", "base": 3.0, "height": 4.0, "color": "red"}, schema
+        )
 
 
 def test_oneofschema_top_level_many_wraps_in_array():
@@ -895,8 +938,9 @@ def test_oneofschema_top_level_many_wraps_in_array():
 
 
 def test_oneofschema_nested_emits_oneof_at_field():
-    """A `fields.Nested(MyOneOfSchema)` should emit a `oneOf` directly
-    in the field's schema, not a `$ref` to a useless empty definition."""
+    """A `fields.Nested(MyOneOfSchema)` should emit an inline `oneOf`
+    directly in the field's schema, with each variant carrying its
+    discriminator."""
     from marshmallow_oneofschema import OneOfSchema
 
     class A(Schema):
@@ -914,8 +958,8 @@ def test_oneofschema_nested_emits_oneof_at_field():
     dumped = validate_and_dump(Container())
     field_schema = dumped["definitions"]["Container"]["properties"]["thing"]
     assert "oneOf" in field_schema
-    refs = sorted(item["$ref"] for item in field_schema["oneOf"])
-    assert refs == ["#/definitions/A", "#/definitions/B"]
+    consts = sorted(v["properties"]["type"]["const"] for v in field_schema["oneOf"])
+    assert consts == ["a", "b"]
 
 
 def test_oneofschema_nested_many_wraps_array():
@@ -936,6 +980,50 @@ def test_oneofschema_nested_many_wraps_array():
     field_schema = dumped["definitions"]["Container"]["properties"]["things"]
     assert field_schema["type"] == "array"
     assert "oneOf" in field_schema["items"]
+
+
+def test_oneofschema_custom_type_field():
+    """A OneOfSchema with a non-default `type_field` (e.g. `kind`)
+    should use that name as the discriminator in the emitted schemas."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class A(Schema):
+        a = fields.Integer()
+
+    class Dispatched(OneOfSchema):
+        type_field = "kind"
+        type_schemas = {"a": A}
+
+    dumped = JSONSchema().dump(Dispatched())
+    variant = dumped["oneOf"][0]
+    assert "kind" in variant["properties"]
+    assert variant["properties"]["kind"]["const"] == "a"
+    assert "kind" in variant["required"]
+
+
+def test_oneofschema_variant_nested_refs_preserved():
+    """When a OneOfSchema variant contains a Nested field, that inner
+    nested schema should still be registered as a top-level definition
+    so the inlined variant's `$ref` resolves."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class Address(Schema):
+        city = fields.String()
+
+    class Person(Schema):
+        name = fields.String()
+        address = fields.Nested(Address)
+
+    class Company(Schema):
+        name = fields.String()
+
+    class Party(OneOfSchema):
+        type_schemas = {"person": Person, "company": Company}
+
+    dumped = JSONSchema().dump(Party())
+    # Address is referenced $ref inside Person's inlined variant, so
+    # it must be registered as a definition.
+    assert "Address" in dumped["definitions"]
 
 
 def test_unsupported_field_error_points_at_fix():

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1026,6 +1026,24 @@ def test_oneofschema_variant_nested_refs_preserved():
     assert "Address" in dumped["definitions"]
 
 
+def test_oneofschema_variant_field_collides_with_discriminator_raises():
+    """If a variant declares its own field with the same name as the
+    OneOfSchema's `type_field`, refuse to silently overwrite it - that
+    would mask a real schema mismatch."""
+    from marshmallow_oneofschema import OneOfSchema
+    from marshmallow_jsonschema.exceptions import UnsupportedValueError
+
+    class Variant(Schema):
+        type = fields.String(required=True)
+        payload = fields.Integer()
+
+    class S(OneOfSchema):
+        type_schemas = {"a": Variant}
+
+    with pytest.raises(UnsupportedValueError, match="discriminator"):
+        JSONSchema().dump(S())
+
+
 def test_unsupported_field_error_points_at_fix():
     """The error raised for an unmappable custom field should tell the
     user how to fix it: subclass an existing field type, or add

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -849,6 +849,95 @@ def test_marshmallow_enum_by_value_strings():
     assert sorted(prop["enum"]) == ["active", "inactive"]
 
 
+def test_oneofschema_top_level_emits_oneof():
+    """`JSONSchema().dump(SomeOneOfSchema())` should emit a top-level
+    `oneOf` over the variant schemas instead of a useless empty
+    definition. Closes #141."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class TriangleSchema(Schema):
+        base = fields.Float(required=True)
+
+    class CircleSchema(Schema):
+        radius = fields.Float(required=True)
+
+    class ShapeSchema(OneOfSchema):
+        type_schemas = {"triangle": TriangleSchema, "circle": CircleSchema}
+
+    dumped = JSONSchema().dump(ShapeSchema())
+    refs = sorted(item["$ref"] for item in dumped["oneOf"])
+    assert refs == ["#/definitions/CircleSchema", "#/definitions/TriangleSchema"]
+    # Each variant is fully described under definitions.
+    assert sorted(dumped["definitions"]) == ["CircleSchema", "TriangleSchema"]
+    assert dumped["definitions"]["TriangleSchema"]["properties"]["base"]["type"] == (
+        "number"
+    )
+
+
+def test_oneofschema_top_level_many_wraps_in_array():
+    """`OneOfSchema(many=True)` at the root should produce an array of
+    polymorphic instances."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class A(Schema):
+        a = fields.Integer()
+
+    class B(Schema):
+        b = fields.String()
+
+    class S(OneOfSchema):
+        type_schemas = {"a": A, "b": B}
+
+    dumped = JSONSchema().dump(S(many=True))
+    assert dumped["type"] == "array"
+    assert "oneOf" in dumped["items"]
+    assert "$ref" not in dumped
+
+
+def test_oneofschema_nested_emits_oneof_at_field():
+    """A `fields.Nested(MyOneOfSchema)` should emit a `oneOf` directly
+    in the field's schema, not a `$ref` to a useless empty definition."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class A(Schema):
+        a = fields.Integer()
+
+    class B(Schema):
+        b = fields.String()
+
+    class S(OneOfSchema):
+        type_schemas = {"a": A, "b": B}
+
+    class Container(Schema):
+        thing = fields.Nested(S)
+
+    dumped = validate_and_dump(Container())
+    field_schema = dumped["definitions"]["Container"]["properties"]["thing"]
+    assert "oneOf" in field_schema
+    refs = sorted(item["$ref"] for item in field_schema["oneOf"])
+    assert refs == ["#/definitions/A", "#/definitions/B"]
+
+
+def test_oneofschema_nested_many_wraps_array():
+    """A `fields.Nested(MyOneOfSchema, many=True)` should array-wrap
+    the `oneOf` (and honor `field.required` like other Nested fields)."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class A(Schema):
+        a = fields.Integer()
+
+    class S(OneOfSchema):
+        type_schemas = {"a": A}
+
+    class Container(Schema):
+        things = fields.Nested(S, many=True, required=True)
+
+    dumped = validate_and_dump(Container())
+    field_schema = dumped["definitions"]["Container"]["properties"]["things"]
+    assert field_schema["type"] == "array"
+    assert "oneOf" in field_schema["items"]
+
+
 def test_unsupported_field_error_points_at_fix():
     """The error raised for an unmappable custom field should tell the
     user how to fix it: subclass an existing field type, or add

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1026,6 +1026,40 @@ def test_oneofschema_variant_nested_refs_preserved():
     assert "Address" in dumped["definitions"]
 
 
+def test_oneofschema_empty_type_schemas_raises():
+    """An empty `type_schemas` would emit `oneOf: []`, which is invalid
+    Draft-07. Refuse rather than produce a broken schema."""
+    from marshmallow_oneofschema import OneOfSchema
+    from marshmallow_jsonschema.exceptions import UnsupportedValueError
+
+    class S(OneOfSchema):
+        type_schemas: dict = {}
+
+    with pytest.raises(UnsupportedValueError, match="empty `type_schemas`"):
+        JSONSchema().dump(S())
+
+
+def test_oneofschema_meta_title_and_description_propagate():
+    """`Meta.title` / `Meta.description` on the OneOfSchema itself should
+    appear alongside the `oneOf` envelope, mirroring how they propagate
+    for regular schemas."""
+    from marshmallow_oneofschema import OneOfSchema
+
+    class A(Schema):
+        a = fields.Integer()
+
+    class S(OneOfSchema):
+        type_schemas = {"a": A}
+
+        class Meta:
+            title = "Polymorphic Thing"
+            description = "Either an A or something else later."
+
+    dumped = JSONSchema().dump(S())
+    assert dumped["title"] == "Polymorphic Thing"
+    assert dumped["description"] == "Either an A or something else later."
+
+
 def test_oneofschema_variant_field_collides_with_discriminator_raises():
     """If a variant declares its own field with the same name as the
     OneOfSchema's `type_field`, refuse to silently overwrite it - that


### PR DESCRIPTION
Closes #141.

## The bug
Dumping a `marshmallow_oneofschema.OneOfSchema` produced an empty definition because `OneOfSchema.fields` is empty — the real fields live in each `type_schemas[type_value]` variant. Output was:
```json
{"definitions": {"ShapeSchema": {"properties": {}, "type": "object", ...}}, "$ref": "#/definitions/ShapeSchema"}
```

## The fix
Detect `OneOfSchema` in two places:
- **Top-level `dump()`**: emit `{"oneOf": [<inlined variants>]}`. Honors `many=True` by wrapping in an array.
- **`_from_nested_schema`**: when a `Nested` field references a `OneOfSchema`, emit `{"oneOf": [<inlined variants>]}` directly at the field site instead of a `$ref` to the empty container. Existing `field.many` / `field.allow_none` / metadata handling on the outer `Nested` field still applies.

Each variant is **inlined** (not `$ref`) so it can carry the discriminator field as a `const`-pinned property. Without this, `OneOfSchema`'s actual wire format (`{"type": "<discriminator>", ...variant_fields}`) would be rejected by strict validators because the variant's standalone definition has `additionalProperties: false` and doesn't declare the discriminator field. `$ref`s discovered inside variants (e.g. inner Nested) are still propagated to the top-level `definitions` so they resolve.

## Discriminator handling
- Each `oneOf` branch declares the discriminator field as `{"type": "string", "const": "<type_value>"}` and adds it to `required`.
- Custom `type_field` (default `"type"`) is honored.
- If a variant declares its own field with the same name as `type_field`, we raise `UnsupportedValueError` rather than silently overwrite — that would hide a real schema mismatch.

## Optional dependency
- `marshmallow-oneofschema` added to `extras_require` as `marshmallow_jsonschema[oneofschema]`
- Detected at import time via `ALLOW_ONEOFSCHEMA` flag (matches `marshmallow_enum` / `marshmallow_union` pattern)
- No effect on consumers who don't have the package installed

## Test plan
- [x] m3: all tests pass
- [x] m4: all tests pass (1 skip is the unrelated by-name enum test)
- [x] mypy / black clean
- [x] CI matrix green (5 Pythons × 2 marshmallow majors + lint + mypy)
- [x] `test_oneofschema_generated_schema_validates_wire_output` runs `jsonschema.validate(...)` against real wire payloads — locks in accept/reject behavior so the validation gap can't regress
- [x] Tests cover: top-level, top-level+many, nested, nested+many, custom `type_field`, inner-`$ref` carry-through, discriminator-name collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)