### PR TITLE
Fix fields.Raw emitting type: string (closes #120)

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -452,6 +452,18 @@ class JSONSchema(Schema):
             schema.pop("default", None)
         return self._wrap_allow_none(schema, field)
 
+    def _from_raw_field(self, obj, field):
+        """`fields.Raw` accepts any value with no formatting, so emit a
+        schema with no `type` constraint. Title, default, allow_none,
+        and metadata still apply via the shared attribute pass."""
+        schema: typing.Dict[str, typing.Any] = {}
+        self._apply_custom_field_attributes(schema, field)
+        # Default title to the field name if metadata didn't supply one.
+        # `setdefault` so user-provided metadata.title wins, matching
+        # `_from_python_type`'s precedence.
+        schema.setdefault("title", field.attribute or field.name or "")
+        return self._wrap_allow_none(schema, field)
+
     def _from_pluck_field(self, obj, field):
         """`fields.Pluck(NestedSchema, "x")` extracts a single field from
         a nested schema. We emit the picked field's schema directly,
@@ -581,6 +593,15 @@ class JSONSchema(Schema):
                 schema = self._from_constant_field(obj, field)
             elif ALLOW_UNIONS and isinstance(field, Union):
                 schema = self._from_union_schema(obj, field)
+            elif type(field) is fields.Raw:
+                # `fields.Raw` is "any value, no formatting" - emit a
+                # type-less schema so any JSON value validates. The
+                # historical mapping to `type: string` was wrong (it
+                # rejected numbers/objects/etc.); closes #120. Exact
+                # type check (not isinstance) so user subclasses of
+                # Raw with their own intent still go through the
+                # normal `_get_python_type` path.
+                schema = self._from_raw_field(obj, field)
             else:
                 pytype = self._get_python_type(field)
                 schema = self._from_python_type(obj, field, pytype)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1130,6 +1130,24 @@ def test_raw_field_accepts_any_json_value():
         jsonschema_lib.validate({"blob": value}, schema)
 
 
+def test_raw_subclass_falls_through_to_get_python_type():
+    """`fields.Raw` itself emits a type-less schema (#120), but a user
+    subclass of `Raw` should still flow through `_get_python_type` and
+    pick up the existing `(Raw, str)` pair mapping. Locks in the
+    `type(field) is fields.Raw` exact-type check in
+    `_get_schema_for_field` so a future swap to `isinstance` doesn't
+    silently change the output for subclasses."""
+
+    class CustomRaw(fields.Raw):
+        pass
+
+    class S(Schema):
+        blob = CustomRaw()
+
+    field_schema = JSONSchema().dump(S())["definitions"]["S"]["properties"]["blob"]
+    assert field_schema["type"] == "string"
+
+
 def test_raw_field_carries_metadata_and_allow_none():
     """Raw fields should still pick up title/description/default/
     allow_none like any other field."""

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1112,6 +1112,45 @@ def test_oneofschema_variant_field_collides_with_discriminator_raises():
         JSONSchema().dump(S())
 
 
+def test_raw_field_accepts_any_json_value():
+    """`fields.Raw` is "any value, no formatting"; the emitted schema
+    must not pin a `type`, otherwise valid wire payloads get rejected.
+    Regression for #120."""
+    import jsonschema as jsonschema_lib
+
+    class S(Schema):
+        blob = fields.Raw()
+
+    schema = JSONSchema().dump(S())
+    jsonschema_lib.Draft7Validator.check_schema(schema)
+    field_schema = schema["definitions"]["S"]["properties"]["blob"]
+    assert "type" not in field_schema
+    # Every JSON-valid value passes through.
+    for value in ["x", 1, 1.5, True, None, {"k": "v"}, [1, 2]]:
+        jsonschema_lib.validate({"blob": value}, schema)
+
+
+def test_raw_field_carries_metadata_and_allow_none():
+    """Raw fields should still pick up title/description/default/
+    allow_none like any other field."""
+
+    class S(Schema):
+        blob = fields.Raw(
+            allow_none=True,
+            dump_default="x",
+            metadata={"title": "Blob", "description": "anything"},
+        )
+
+    field_schema = JSONSchema().dump(S())["definitions"]["S"]["properties"]["blob"]
+    # allow_none wraps in anyOf
+    assert "anyOf" in field_schema
+    inner = field_schema["anyOf"][0]
+    assert inner["title"] == "Blob"
+    assert inner["description"] == "anything"
+    assert inner["default"] == "x"
+    assert field_schema["anyOf"][1] == {"type": "null"}
+
+
 def test_unsupported_field_error_points_at_fix():
     """The error raised for an unmappable custom field should tell the
     user how to fix it: subclass an existing field type, or add


### PR DESCRIPTION
Closes #120.

## The bug
`marshmallow.fields.Raw` is "Field that applies no formatting" — it accepts any value with no transformation. The historical mapping in `MARSHMALLOW_TO_PY_TYPES_PAIRS` routed it through `str` → \`{\"type\": \"string\"}\`, so a Raw field that's actually used to carry a dict, number, or list produced a schema that rejected the real wire format.

\`\`\`python
class S(Schema):
    blob = fields.Raw()

JSONSchema().dump(S())
# blob -> {\"title\": \"blob\", \"type\": \"string\"}   <-- wrong
\`\`\`

## The fix
Special-case \`type(field) is fields.Raw\` in \`_get_schema_for_field\` and emit a schema with no \`type\` constraint (Draft-7 treats this as "any value"). Title, default, allow_none, and metadata still apply via the shared attribute pass.

\`\`\`python
# blob -> {\"title\": \"blob\"}                         <-- accepts any JSON value
\`\`\`

Exact type check (not \`isinstance\`) so user subclasses of Raw with their own intent still flow through the normal \`_get_python_type\` path and pick up the existing pair mapping for backwards compatibility.

## Behavior change
Anyone relying on the previous \`type: string\` output for Raw fields will see no \`type\` key. But those callers were already getting incorrect validation — any non-string wire value would have failed against the dumped schema even though Raw accepts it on the marshmallow side. So this is a bugfix, not a feature.

## Test plan
- [x] m3: 83 passed
- [x] m4: 82 + 1 skipped
- [x] mypy / black clean
- [x] New \`test_raw_field_accepts_any_json_value\` validates the dumped schema is itself Draft-7 valid AND accepts string/int/float/bool/null/object/array values
- [x] New \`test_raw_field_carries_metadata_and_allow_none\` covers metadata + allow_none precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)