### PR TITLE
Fix Makefile release targets for PEP 625 + correct testpypi name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,24 +30,19 @@ test_coverage:
 	pytest --cov-report html --cov-config .coveragerc --cov $(PROJECT)
 
 clean_build_and_dist:
-	if [ -d build/ ]; then \
-		rm -rf build/ dist/ ; \
-	fi
+	rm -rf build/ dist/
 
-sdist: clean_build_and_dist
-	python setup.py sdist
-
-bdist_wheel:
-	pip install -U wheel
-	python setup.py bdist_wheel
+build_pkg: clean_build_and_dist
+	pip install -U build
+	python -m build
 
 twine:
 	pip install -U twine
 
-pypitest: sdist bdist_wheel twine
-	twine upload -r pypitest dist/*
+pypitest: build_pkg twine
+	twine upload -r testpypi dist/*
 
-pypi: sdist bdist_wheel twine
+pypi: build_pkg twine
 	twine upload -r pypi dist/*
 
 


### PR DESCRIPTION
## Summary
The 0.16.0 release surfaced two breakage points in \`make pypi\` / \`make pypitest\`:

- **PEP 625 sdist filename**: \`python setup.py sdist\` produces hyphenated tarballs (\`marshmallow-jsonschema-X.Y.Z.tar.gz\`) which PyPI now rejects — it requires the normalized underscore form. Switched the build to \`python -m build\`, which emits both sdist and wheel with the correct names in one step.
- **Wrong twine repo name**: \`make pypitest\` invoked \`twine upload -r pypitest\`, but the standard \`~/.pypirc\` section is \`testpypi\`. Renamed to match.
- **Stale dist artifacts**: \`clean_build_and_dist\` only ran when \`build/\` existed, which left stale wheels/sdists from prior releases in \`dist/\`. Always clean both.

## Test plan
- [ ] Next release: \`make pypitest\` uploads cleanly to TestPyPI
- [ ] Next release: \`make pypi\` uploads cleanly to PyPI
- [ ] \`dist/\` contains only the current version's artifacts after \`make pypi\`